### PR TITLE
머티리얼 아이템 텍스트 재작업

### DIFF
--- a/translations/binaries/slps_strings_items_consumable.json
+++ b/translations/binaries/slps_strings_items_consumable.json
@@ -5,7 +5,7 @@
             "string": "リライズで、与えるダメージが２倍[LINE]\nになる宝石に変化する。ただし……[LINE]\n[END]",
             "original_bytes_length": 67,
             "available_bytes_size": 71,
-            "translation": "리라이즈로, 주는 피해가 2배 [LINE]\n되는 보석으로 변하게 됩니다. 단…[LINE]\n[END]"
+            "translation": "리라이즈하면 주는 데미지가 2배가[LINE]\n되는 보석으로 변화한다. 다만……[LINE]\n[END]"
         },
         {
             "offset": 1754488,
@@ -17,7 +17,7 @@
         {
             "offset": 1754512,
             "string": "リライズで、獲得経験値が２倍に[LINE]\nなる宝石に変化する。ただし……[LINE]\n[END]",
-            "translation": "리라이즈로, 획득 경험치가 2배로[LINE]\n되는 보석으로 변화한다. 다만……[LINE]\n[END]",
+            "translation": "리라이즈하면 획득 경험치가 2배가[LINE]\n되는 보석으로 변화한다. 다만……[LINE]\n[END]",
             "original_bytes_length": 63,
             "available_bytes_size": 63
         },
@@ -31,7 +31,7 @@
         {
             "offset": 1754600,
             "string": "リライズで、フラッシュガード[LINE]\n（敵の攻撃をひきつけてガード）[LINE]\nでＨＰが回復する宝石に変化する。[END]",
-            "translation": "리라이즈로, 플래시 가드[LINE]\n(적의 공격을 끌어들여 가드)[LINE]\n로 HP가 회복하는 보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 플래시 가드[LINE]\n(적의 공격을 끌어들여 가드) 했을 때[LINE]\nHP가 회복되는 보석으로 변화한다.[END]",
             "original_bytes_length": 93,
             "available_bytes_size": 95
         },
@@ -45,7 +45,7 @@
         {
             "offset": 1754728,
             "string": "リライズで、フラッシュガード[LINE]\n（敵の攻撃をひきつけてガード）[LINE]\nでＣＣが２加算する宝石に変化する。[END]",
-            "translation": "리라이즈로, 플래시 가드[LINE]\n(적의 공격을 끌어들여 가드)[LINE]\n로 CC가 2 추가하는 보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 플래시 가드[LINE]\n(적의 공격을 끌어들여 가드) 했을 때[LINE]\nCC가 2 오르는 보석으로 변화한다.[END]",
             "original_bytes_length": 95,
             "available_bytes_size": 95
         },
@@ -59,7 +59,7 @@
         {
             "offset": 1754856,
             "string": "リライズで、エイミングダッシュ中[LINE]\n物理攻撃を防御できる宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 에이밍 대쉬 중[LINE]\n물리 공격을 방어할 수 있는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 에이밍 대시 중[LINE]\n물리 공격을 방어할 수 있는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71
         },
@@ -73,7 +73,7 @@
         {
             "offset": 1754960,
             "string": "リライズで、敵を倒したときに、[LINE]\nブラストゲージが加算される宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 적을 쓰러트렸을 때,[LINE]\n블라스트 게이지가 추가되는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 적을 쓰러트렸을 때,[LINE]\n블라스트 게이지가 오르는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 75,
             "available_bytes_size": 79
         },
@@ -87,7 +87,7 @@
         {
             "offset": 1755072,
             "string": "リライズで、敵を倒したときに、[LINE]\nＣＣを＋２する宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 적을 쓰러트렸을 때,[LINE]\nCC를 +2 하는 보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 적을 쓰러트렸을 때,[LINE]\nCC를 +2 하는 보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 63,
             "available_bytes_size": 63
         },
@@ -101,7 +101,7 @@
         {
             "offset": 1755160,
             "string": "リライズで、敵を倒したときに、[LINE]\nＨＰが回復する宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 적을 쓰러트렸을 때,[LINE]\nHP가 회복하는 보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 적을 쓰러트렸을 때,[LINE]\nHP가 회복되는 보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 63,
             "available_bytes_size": 63
         },
@@ -115,7 +115,7 @@
         {
             "offset": 1755248,
             "string": "リライズで、一定時間毎に[LINE]\nＨＰが微量回復する宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 일정 시간마다[LINE]\nHP가 미량 회복하는 보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 일정 시간마다[LINE]\nHP가 미량 회복되는 보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 61,
             "available_bytes_size": 63
         },
@@ -129,7 +129,7 @@
         {
             "offset": 1755336,
             "string": "リライズで、クリティカル時に[LINE]\nＣＣを＋１する宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 크리티컬 시에[LINE]\nCC를 +1 하는 보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 크리티컬이 발생했을 때[LINE]\nCC를 +1 하는 보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 61,
             "available_bytes_size": 63
         },
@@ -143,7 +143,7 @@
         {
             "offset": 1755432,
             "string": "リライズで、ＣＣを平均で固定に[LINE]\nする宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, CC를 평균으로 고정하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 CC를 평균으로 고정하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 53,
             "available_bytes_size": 55
         },
@@ -157,7 +157,7 @@
         {
             "offset": 1755512,
             "string": "リライズで、ＣＣを常に１５にする[LINE]\n宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, CC를 항상 15로 하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 CC를 항상 15로 하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 51,
             "available_bytes_size": 55
         },
@@ -171,7 +171,7 @@
         {
             "offset": 1755600,
             "string": "リライズで、最小ＣＣと最大ＣＣを[LINE]\n１増やす宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 최소 CC와 최대 CC를[LINE]\n1 증가하는 보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 최소 CC와 최대 CC가[LINE]\n1 증가하는 보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -185,21 +185,21 @@
         {
             "offset": 1755696,
             "string": "リライズで、最大ＣＣを２増やす[LINE]\n宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 최대 CC를 2 증가하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 최대 CC가 2 증가하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55
         },
         {
             "offset": 1755752,
             "string": "[Sign_8]ゼクシードマテリアル[END]",
-            "translation": "[Sign_8]제크시드 머티리얼[END]",
+            "translation": "[Sign_8]젝시드 머티리얼[END]",
             "original_bytes_length": 26,
             "available_bytes_size": 31
         },
         {
             "offset": 1755784,
             "string": "リライズで、最大ＣＣを１増やす[LINE]\n宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 최대 CC를 1 증가하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 최대 CC가 1 증가하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55
         },
@@ -213,7 +213,7 @@
         {
             "offset": 1755872,
             "string": "リライズで、最小ＣＣを１増やす[LINE]\n宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 최소 CC를 1 증가하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 최소 CC가 1 증가하는[LINE]\n보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55
         },
@@ -227,7 +227,7 @@
         {
             "offset": 1755952,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\n減少効果を打ち消す宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n감소 효과를 상쇄하는 보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n감소 효과를 무효화하는 보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79
         },
@@ -241,7 +241,7 @@
         {
             "offset": 1756064,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\n敵の防御を崩す攻撃判定が[LINE]\n発生する宝石に変化する。[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n적의 방어를 무너뜨리는 공격 판정이[LINE]\n발생하는 보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n적의 방어를 무너뜨리는 공격 판정이[LINE]\n발생하는 보석으로 변화한다.[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87
         },
@@ -255,7 +255,7 @@
         {
             "offset": 1756184,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\nＨＰを回復する宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\nHP를 회복하는 보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\nHP가 회복되는 보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 69,
             "available_bytes_size": 71
         },
@@ -269,7 +269,7 @@
         {
             "offset": 1756280,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\n自分以外の味方のＣＣを[LINE]\n加算させる宝石に変化する。[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n자신 이외의 아군의 CC를[LINE]\n추가하는 보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n자신 이외의 아군의 CC가[LINE]\n오르는 보석으로 변화한다.[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87
         },
@@ -283,7 +283,7 @@
         {
             "offset": 1756392,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\nブラストゲージを加算する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n블라스트 게이지를 추가하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n블라스트 게이지가 오르는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 79,
             "available_bytes_size": 79
         },
@@ -297,7 +297,7 @@
         {
             "offset": 1756496,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\n短時間完全回避する宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n단시간 완전 회피하는 보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n짧은 시간동안 모든 공격을 회피하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79
         },
@@ -311,7 +311,7 @@
         {
             "offset": 1756608,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\nＣＣを１加算する宝石に変化する。[LINE]\n[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\nCC를 1 추가하는 보석으로 변화한다.[LINE]\n[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\nCC가 1 오르는 보석으로 변화한다.[LINE]\n[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71
         },
@@ -325,7 +325,7 @@
         {
             "offset": 1756704,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\n高確率で状態異常を解除する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n고확률로 상태이상을 해제하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n고확률로 상태이상을 해제하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -339,7 +339,7 @@
         {
             "offset": 1756816,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\n術防御力を一定時間上昇する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n술 방어력을 일정 시간 상승하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n술 방어력이 일정 시간 상승하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -353,7 +353,7 @@
         {
             "offset": 1756928,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\n防御力を一定時間上昇する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n방어력을 일정 시간 상승하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n방어력이 일정 시간 상승하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 79,
             "available_bytes_size": 79
         },
@@ -367,7 +367,7 @@
         {
             "offset": 1757040,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\n術攻撃力を一定時間上昇する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n술 공격력을 일정 시간 상승하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n술 공격력이 일정 시간 상승하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -381,7 +381,7 @@
         {
             "offset": 1757152,
             "string": "リライズで、戦闘中、[Square_ani2]＋[Down_blink]で、[LINE]\n攻撃力を一定時間上昇する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 전투 중, [Square_ani2]＋[Down_blink]로,[LINE]\n공격력을 일정 시간 상승하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n공격력이 일정 시간 상승하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 79,
             "available_bytes_size": 79
         },
@@ -395,7 +395,7 @@
         {
             "offset": 1757256,
             "string": "リライズで、音属性ダメージを半減[LINE]\nできる「音属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 소리속성 데미지를 반감[LINE]\n할 수 있는「소리속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 소리속성 데미지를[LINE]\n반감할 수 있는 「소리속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -409,7 +409,7 @@
         {
             "offset": 1757368,
             "string": "リライズで、射属性ダメージを半減[LINE]\nできる「射属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 사속성 데미지를 반감[LINE]\n할 수 있는「사속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 사격속성 데미지를[LINE]\n반감할 수 있는 「사격속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -423,7 +423,7 @@
         {
             "offset": 1757480,
             "string": "リライズで、打属性ダメージを半減[LINE]\nできる「打属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 타격속성 데미지를 반감[LINE]\n할 수 있는「타격속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 타격속성 데미지를[LINE]\n반감할 수 있는 「타격속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -437,7 +437,7 @@
         {
             "offset": 1757592,
             "string": "リライズで、斬属性ダメージを半減[LINE]\nできる「斬属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 참속성 데미지를 반감[LINE]\n할 수 있는「참속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 참격속성 데미지를[LINE]\n반감할 수 있는 「참격속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -451,7 +451,7 @@
         {
             "offset": 1757712,
             "string": "リライズで、闇属性ダメージを半減[LINE]\nできる「闇属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 어둠속성 데미지를 반감[LINE]\n할 수 있는「어둠속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 어둠속성 데미지를[LINE]\n반감할 수 있는 「어둠속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -465,7 +465,7 @@
         {
             "offset": 1757824,
             "string": "リライズで、光属性ダメージを半減[LINE]\nできる「光属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 빛속성 데미지를 반감[LINE]\n할 수 있는「빛속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 빛속성 데미지를[LINE]\n반감할 수 있는 「빛속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -479,7 +479,7 @@
         {
             "offset": 1757936,
             "string": "リライズで、風属性ダメージを半減[LINE]\nできる「風属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 바람속성 데미지를 반감[LINE]\n할 수 있는「바람속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 바람속성 데미지를[LINE]\n반감할 수 있는 「바람속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -493,7 +493,7 @@
         {
             "offset": 1758048,
             "string": "リライズで、地属性ダメージを半減[LINE]\nできる「地属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 땅속성 데미지를 반감[LINE]\n할 수 있는「땅속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 땅속성 데미지를[LINE]\n반감할 수 있는 「땅속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -507,7 +507,7 @@
         {
             "offset": 1758160,
             "string": "リライズで、水属性ダメージを半減[LINE]\nできる「水属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 물속성 데미지를 반감[LINE]\n할 수 있는「물속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 물속성 데미지를[LINE]\n반감할 수 있는 「물속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -521,7 +521,7 @@
         {
             "offset": 1758272,
             "string": "リライズで、火属性ダメージを半減[LINE]\nできる「火属性耐性」を付加する[LINE]\n宝石に変化する。[END]",
-            "translation": "리라이즈로, 불속성 데미지를 반감[LINE]\n할 수 있는「불속성 내성」을 부여하는[LINE]\n보석으로 변화한다.[END]",
+            "translation": "리라이즈하면 불속성 데미지를[LINE]\n반감할 수 있는 「불속성 내성」을[LINE]\n부여하는 보석으로 변화한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -535,7 +535,7 @@
         {
             "offset": 1758384,
             "string": "リライズで、術技が使用不可になる[LINE]\n状態異常「封印」を防止する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 술기가 사용 불가능이 되는[LINE]\n상태이상「봉인」을 방지하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 술기를 사용할 수 없게 되는[LINE]\n상태이상 「봉인」을 방지하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 77,
             "available_bytes_size": 79
         },
@@ -549,7 +549,7 @@
         {
             "offset": 1758488,
             "string": "リライズで、行動時に痺れる[LINE]\n状態異常「マヒ」を防止する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 행동 시에 마비되는[LINE]\n상태이상「마비」를 방지하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 행동 시에 몸이 저리는[LINE]\n상태이상 「마비」를 방지하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71
         },
@@ -563,7 +563,7 @@
         {
             "offset": 1758584,
             "string": "リライズで、ＣＣの回復が遅くなる[LINE]\n状態異常「衰弱」を防止する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, CC의 회복이 느려지는[LINE]\n상태이상「쇠약」을 방지하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 CC의 회복이 느려지는[LINE]\n상태이상 「쇠약」을 방지하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 77,
             "available_bytes_size": 79
         },
@@ -577,7 +577,7 @@
         {
             "offset": 1758696,
             "string": "リライズで、行動不能になる[LINE]\n状態異常「石化」を防止する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 행동 불능이 되는[LINE]\n상태이상「석화」를 방지하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 행동 불능이 되는[LINE]\n상태이상 「석화」를 방지하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71
         },
@@ -591,7 +591,7 @@
         {
             "offset": 1758792,
             "string": "リライズで、行動不能になる[LINE]\n状態異常「睡眠」を防止する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, 행동 불능이 되는[LINE]\n상태이상「수면」을 방지하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 행동 불능이 되는[LINE]\n상태이상 「수면」을 방지하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71
         },
@@ -605,7 +605,7 @@
         {
             "offset": 1758888,
             "string": "リライズで、ＨＰが減少していく[LINE]\n状態異常「熱毒」を防止する宝石に[LINE]\n変化する。[END]",
-            "translation": "리라이즈로, HP가 감소해 가는[LINE]\n상태이상「열독」을 방지하는 보석으로[LINE]\n변화한다.[END]",
+            "translation": "리라이즈하면 HP가 계속 감소하는[LINE]\n상태이상 「열독」을 방지하는[LINE]\n보석으로 변화한다.[END]",
             "original_bytes_length": 75,
             "available_bytes_size": 79
         },

--- a/translations/binaries/slps_strings_items_jewel.json
+++ b/translations/binaries/slps_strings_items_jewel.json
@@ -3,21 +3,21 @@
         {
             "offset": 1768720,
             "string": "[Sign_2]なりきりリリス[END]",
-            "translation": "[Sign_2]나리키리 릴리스[END]",
+            "translation": "[Sign_2]나리키리 리리스[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
         {
             "offset": 1768744,
             "string": "[Sign_2]なりきりコングマン[END]",
-            "translation": "[Sign_2]나리키리 콩그맨[END]",
+            "translation": "[Sign_2]나리키리 콩맨[END]",
             "original_bytes_length": 24,
             "available_bytes_size": 24
         },
         {
             "offset": 1768768,
             "string": "[Sign_2]なりきりジョニー[END]",
-            "translation": "[Sign_2]나리키리 존니[END]",
+            "translation": "[Sign_2]나리키리 죠니[END]",
             "original_bytes_length": 22,
             "available_bytes_size": 23
         },
@@ -66,14 +66,14 @@
         {
             "offset": 1768936,
             "string": "なりきりの力が宿っている？[LINE]\n[LINE]\n[END]",
-            "translation": "나리키리의 힘이 숙박하고 있는?[LINE]\n[LINE]\n[END]",
+            "translation": "나리키리의 힘이 깃들어 있다?[LINE]\n[LINE]\n[END]",
             "original_bytes_length": 29,
             "available_bytes_size": 31
         },
         {
             "offset": 1768968,
             "string": "[Sign_2]なりきりスタン[END]",
-            "translation": "[Sign_2]나리키리 스탠[END]",
+            "translation": "[Sign_2]나리키리 스탄[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
@@ -94,7 +94,7 @@
         {
             "offset": 1769056,
             "string": "獲得経験値が２倍になる宝石。[LINE]\nただし……[LINE]\n[END]",
-            "translation": "획득 경험이 2배가 되는 보석.[LINE]\n다만……[LINE]\n[END]",
+            "translation": "획득 경험치가 2배가 되는 보석.[LINE]\n다만……[LINE]\n[END]",
             "original_bytes_length": 41,
             "available_bytes_size": 47
         },
@@ -108,21 +108,21 @@
         {
             "offset": 1769120,
             "string": "フラッシュガード[LINE]\n（敵の攻撃をひきつけてガード）[LINE]\nでＨＰが回復する宝石。[END]",
-            "translation": "플래시 가드[LINE]\n(적의 공격을 끌어내어 가드)[LINE]\n로 HP가 회복하는 보석.[END]",
+            "translation": "플래시 가드[LINE]\n(적의 공격을 끌어내어 가드)[LINE]\n했을 때 HP가 회복되는 보석.[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71
         },
         {
             "offset": 1769192,
             "string": "[Sign_2]アブソーブ[END]",
-            "translation": "[Sign_2]어브소브[END]",
+            "translation": "[Sign_2]앱소브[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16
         },
         {
             "offset": 1769208,
             "string": "フラッシュガード[LINE]\n（敵の攻撃をひきつけてガード）[LINE]\nでＣＣが２加算する宝石。[END]",
-            "translation": "플래시 가드[LINE]\n(적의 공격을 끌어내어 가드)[LINE]\n로 CC가 2 추가하는 보석.[END]",
+            "translation": "플래시 가드[LINE]\n(적의 공격을 끌어내어 가드)[LINE]\n했을 때 CC가 2 오르는 보석.[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79
         },
@@ -150,7 +150,7 @@
         {
             "offset": 1769376,
             "string": "敵を倒したときにブラストゲージが[LINE]\n加算される宝石。[LINE]\n[END]",
-            "translation": "적을 쓰러트렸을 때 블라스트 게이지가[LINE]\n추가되는 보석.[LINE]\n[END]",
+            "translation": "적을 쓰러트렸을 때[LINE]\n블라스트 게이지가 오르는 보석.[LINE]\n[END]",
             "original_bytes_length": 51,
             "available_bytes_size": 55
         },
@@ -164,7 +164,7 @@
         {
             "offset": 1769448,
             "string": "敵を倒したときにＣＣを＋２する[LINE]\n宝石。[LINE]\n[END]",
-            "translation": "적을 쓰러트렸을 때 CC를 +2 하는[LINE]\n보석.[LINE]\n[END]",
+            "translation": "적을 쓰러트렸을 때[LINE]\nCC를 +2 하는 보석.[LINE]\n[END]",
             "original_bytes_length": 39,
             "available_bytes_size": 39
         },
@@ -178,7 +178,7 @@
         {
             "offset": 1769504,
             "string": "敵を倒したときにＨＰが回復する[LINE]\n宝石。[LINE]\n[END]",
-            "translation": "적을 쓰러트렸을 때 HP가 회복하는[LINE]\n보석.[LINE]\n[END]",
+            "translation": "적을 쓰러트렸을 때[LINE]\nHP가 회복되는 보석.[LINE]\n[END]",
             "original_bytes_length": 39,
             "available_bytes_size": 39
         },
@@ -192,7 +192,7 @@
         {
             "offset": 1769560,
             "string": "一定時間毎にＨＰが微量回復する[LINE]\n宝石。[LINE]\n[END]",
-            "translation": "일정 시간마다 HP가 미량 회복하는[LINE]\n보석.[LINE]\n[END]",
+            "translation": "일정 시간마다 HP가[LINE]\n미량 회복되는 보석.[LINE]\n[END]",
             "original_bytes_length": 39,
             "available_bytes_size": 39
         },
@@ -206,7 +206,7 @@
         {
             "offset": 1769616,
             "string": "クリティカル時にＣＣを＋１する[LINE]\n宝石。[LINE]\n[END]",
-            "translation": "크리티컬 시에 CC를 +1 하는[LINE]\n보석.[LINE]\n[END]",
+            "translation": "크리티컬이 발생했을 때[LINE]\nCC를 +1 하는 보석.[LINE]\n[END]",
             "original_bytes_length": 39,
             "available_bytes_size": 39
         },
@@ -248,35 +248,35 @@
         {
             "offset": 1769768,
             "string": "最小ＣＣと最大ＣＣを１増やす宝石。[LINE]\n[LINE]\n[END]",
-            "translation": "최소 CC와 최대 CC를 1 추가하는 보석.[LINE]\n[LINE]\n[END]",
+            "translation": "최소 CC와 최대 CC가 1 증가하는 보석.[LINE]\n[LINE]\n[END]",
             "original_bytes_length": 37,
             "available_bytes_size": 39
         },
         {
             "offset": 1769808,
             "string": "[Sign_2]バリアブル[END]",
-            "translation": "[Sign_2]바리어블[END]",
+            "translation": "[Sign_2]베리어블[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16
         },
         {
             "offset": 1769824,
             "string": "最大ＣＣを２増やす宝石。[LINE]\n[LINE]\n[END]",
-            "translation": "최대 CC를 2 추가하는 보석.[LINE]\n[LINE]\n[END]",
+            "translation": "최대 CC가 2 증가하는 보석.[LINE]\n[LINE]\n[END]",
             "original_bytes_length": 27,
             "available_bytes_size": 31
         },
         {
             "offset": 1769856,
             "string": "[Sign_2]ゼクシード[END]",
-            "translation": "[Sign_2]제크시드[END]",
+            "translation": "[Sign_2]젝시드[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16
         },
         {
             "offset": 1769872,
             "string": "最大ＣＣを１増やす宝石。[LINE]\n[LINE]\n[END]",
-            "translation": "최대 CC를 1 추가하는 보석.[LINE]\n[LINE]\n[END]",
+            "translation": "최대 CC가 1 증가하는 보석.[LINE]\n[LINE]\n[END]",
             "original_bytes_length": 27,
             "available_bytes_size": 31
         },
@@ -290,7 +290,7 @@
         {
             "offset": 1769920,
             "string": "最小ＣＣを１増やす宝石。[LINE]\n[LINE]\n[END]",
-            "translation": "최소 CC를 1 추가하는 보석.[LINE]\n[LINE]\n[END]",
+            "translation": "최소 CC가 1 증가하는 보석.[LINE]\n[LINE]\n[END]",
             "original_bytes_length": 27,
             "available_bytes_size": 31
         },
@@ -304,7 +304,7 @@
         {
             "offset": 1769968,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\n減少効果を打ち消す宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n감소 효과를 무효화하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n감소 효과를 무효화하는 보석.[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55
         },
@@ -318,7 +318,7 @@
         {
             "offset": 1770040,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\n敵の防御を崩す攻撃判定が[LINE]\n発生する宝石。[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n적의 방어를 무너뜨리는 공격 판정이[LINE]\n발생하는 보석.[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n적의 방어를 무너뜨리는 공격 판정이[LINE]\n발생하는 보석.[END]",
             "original_bytes_length": 63,
             "available_bytes_size": 63
         },
@@ -332,7 +332,7 @@
         {
             "offset": 1770120,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\nＨＰを回復する宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\nHP를 회복하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\nHP가 회복되는 보석.[LINE]\n[END]",
             "original_bytes_length": 45,
             "available_bytes_size": 47
         },
@@ -346,7 +346,7 @@
         {
             "offset": 1770184,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\n自分以外の味方のＣＣを[LINE]\n加算させる宝石。[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n자신 이외의 아군의 CC를[LINE]\n추가하는 보석.[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n자신 이외의 아군의 CC가[LINE]\n오르는 보석.[END]",
             "original_bytes_length": 63,
             "available_bytes_size": 63
         },
@@ -360,7 +360,7 @@
         {
             "offset": 1770264,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\nブラストゲージを加算する宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n블라스트 게이지를 추가하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n블라스트 게이지가 오르는 보석.[LINE]\n[END]",
             "original_bytes_length": 55,
             "available_bytes_size": 55
         },
@@ -374,7 +374,7 @@
         {
             "offset": 1770336,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\n短時間完全回避する宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n단시간 완전 회피하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n짧은 시간동안 모든 공격을[LINE]\n회피하는 보석.[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55
         },
@@ -388,7 +388,7 @@
         {
             "offset": 1770408,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\nＣＣを１加算する宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\nCC를 1 추가하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\nCC가 1 오르는 보석.[LINE]\n[END]",
             "original_bytes_length": 47,
             "available_bytes_size": 47
         },
@@ -402,7 +402,7 @@
         {
             "offset": 1770472,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\n高確率で状態異常を解除する宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n고확률로 상태이상을 해제하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n고확률로 상태이상을 해제하는 보석.[LINE]\n[END]",
             "original_bytes_length": 57,
             "available_bytes_size": 63
         },
@@ -416,7 +416,7 @@
         {
             "offset": 1770552,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\n術防御力を一定時間上昇する宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n술 방어력을 일정 시간 상승하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n술 방어력이 일정 시간 상승하는 보석.[LINE]\n[END]",
             "original_bytes_length": 57,
             "available_bytes_size": 63
         },
@@ -430,7 +430,7 @@
         {
             "offset": 1770632,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\n防御力を一定時間上昇する宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n방어력을 일정 시간 상승하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n방어력이 일정 시간 상승하는 보석.[LINE]\n[END]",
             "original_bytes_length": 55,
             "available_bytes_size": 55
         },
@@ -444,7 +444,7 @@
         {
             "offset": 1770704,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\n術攻撃力を一定時間上昇する宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n술 공격력을 일정 시간 상승하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n술 공격력이 일정 시간 상승하는 보석.[LINE]\n[END]",
             "original_bytes_length": 57,
             "available_bytes_size": 63
         },
@@ -458,7 +458,7 @@
         {
             "offset": 1770784,
             "string": "戦闘中、[Square_ani2]＋[Down_blink]で[LINE]\n攻撃力を一定時間上昇する宝石。[LINE]\n[END]",
-            "translation": "전투 중, [Square_ani2]＋[Down_blink]로[LINE]\n공격력을 일정 시간 상승하는 보석.[LINE]\n[END]",
+            "translation": "전투 중 [Square_ani2]＋[Down_blink]입력으로[LINE]\n공격력이 일정 시간 상승하는 보석.[LINE]\n[END]",
             "original_bytes_length": 55,
             "available_bytes_size": 55
         },
@@ -472,7 +472,7 @@
         {
             "offset": 1770856,
             "string": "音属性ダメージを半減できる[LINE]\n「音属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "음 속성 데미지를 반감할 수 있는[LINE]\n「음 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "소리속성 데미지를 반감할 수 있는[LINE]\n「소리속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -486,7 +486,7 @@
         {
             "offset": 1770936,
             "string": "射属性ダメージを半減できる[LINE]\n「射属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "사 속성 데미지를 반감할 수 있는[LINE]\n「사 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "사격속성 데미지를 반감할 수 있는[LINE]\n「사격속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -500,7 +500,7 @@
         {
             "offset": 1771016,
             "string": "打属性ダメージを半減できる[LINE]\n「打属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "때 속성 데미지를 반감할 수 있는[LINE]\n「때 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "타격속성 데미지를 반감할 수 있는[LINE]\n「타격속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -514,7 +514,7 @@
         {
             "offset": 1771096,
             "string": "斬属性ダメージを半減できる[LINE]\n「斬属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "참 속성 데미지를 반감할 수 있는[LINE]\n「참 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "참격속성 데미지를 반감할 수 있는[LINE]\n「참격속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -528,7 +528,7 @@
         {
             "offset": 1771176,
             "string": "闇属性ダメージを半減できる[LINE]\n「闇属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "어둠 속성 데미지를 반감할 수 있는[LINE]\n「어둠 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "어둠속성 데미지를 반감할 수 있는[LINE]\n「어둠속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -542,7 +542,7 @@
         {
             "offset": 1771256,
             "string": "光属性ダメージを半減できる[LINE]\n「光属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "빛 속성 데미지를 반감할 수 있는[LINE]\n「빛 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "빛속성 데미지를 반감할 수 있는[LINE]\n「빛속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -556,7 +556,7 @@
         {
             "offset": 1771336,
             "string": "風属性ダメージを半減できる[LINE]\n「風属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "바람 속성 데미지를 반감할 수 있는[LINE]\n「바람 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "바람속성 데미지를 반감할 수 있는[LINE]\n「바람속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -570,7 +570,7 @@
         {
             "offset": 1771416,
             "string": "地属性ダメージを半減できる[LINE]\n「地属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "땅 속성 데미지를 반감할 수 있는[LINE]\n「땅 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "땅속성 데미지를 반감할 수 있는[LINE]\n「땅속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -584,7 +584,7 @@
         {
             "offset": 1771496,
             "string": "水属性ダメージを半減できる[LINE]\n「水属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "물 속성 데미지를 반감할 수 있는[LINE]\n「물 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "물속성 데미지를 반감할 수 있는[LINE]\n「물속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -598,7 +598,7 @@
         {
             "offset": 1771576,
             "string": "火属性ダメージを半減できる[LINE]\n「火属性耐性」を付加する宝石。[LINE]\n[END]",
-            "translation": "불 속성 데미지를 반감할 수 있는[LINE]\n「불 속성 내성」을 부여하는 보석.[LINE]\n[END]",
+            "translation": "불속성 데미지를 반감할 수 있는[LINE]\n「불속성 내성」을 부여하는 보석.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
@@ -612,28 +612,28 @@
         {
             "offset": 1771656,
             "string": "術技が使用不可になる状態異常[LINE]\n「封印」を防止する宝石。[LINE]\n[END]",
-            "translation": "술기가 사용 불가능이 되는 상태이상[LINE]\n「봉인」을 방지하는 보석.[LINE]\n[END]",
+            "translation": "술기를 사용할 수 없게 되는 상태이상[LINE]\n「봉인」을 방지하는 보석.[LINE]\n[END]",
             "original_bytes_length": 55,
             "available_bytes_size": 55
         },
         {
             "offset": 1771712,
             "string": "[Sign_2]シール[END]",
-            "translation": "[Sign_2]씰[END]",
+            "translation": "[Sign_2]실[END]",
             "original_bytes_length": 12,
             "available_bytes_size": 15
         },
         {
             "offset": 1771728,
             "string": "行動時に痺れる状態異常[LINE]\n「マヒ」を防止する宝石。[LINE]\n[END]",
-            "translation": "행동 시에 저리는 상태이상[LINE]\n「마비」를 방지하는 보석.[LINE]\n[END]",
+            "translation": "행동 시에 몸이 저리는 상태이상[LINE]\n「마비」를 방지하는 보석.[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55
         },
         {
             "offset": 1771784,
             "string": "[Sign_2]パラライ[END]",
-            "translation": "[Sign_2]파라라이[END]",
+            "translation": "[Sign_2]패럴라이[END]",
             "original_bytes_length": 14,
             "available_bytes_size": 15
         },
@@ -682,7 +682,7 @@
         {
             "offset": 1772016,
             "string": "ＨＰが減少していく状態異常[LINE]\n「熱毒」を防止する宝石。[LINE]\n[END]",
-            "translation": "HP가 감소하는 상태이상[LINE]\n「열독」을 방지하는 보석.[LINE]\n[END]",
+            "translation": "HP가 계속 감소하는 상태이상[LINE]\n「열독」을 방지하는 보석.[LINE]\n[END]",
             "original_bytes_length": 53,
             "available_bytes_size": 55
         },


### PR DESCRIPTION
slps_strings_items_consumable.json 내의 머티리얼+
slps_strings_items_jewel.json 아이템 텍스트 수정입니다

1. 보석 아이템 이름 consumable 파일 내의 머티리얼 기준으로 맞춰뒀습니다
2. 나리키리 아이템 이름 캐릭터 이름 기준으로 맞춰뒀습니다
3. CC 관련 효과가 加算하고 増やす하고 ＋n으로 텍스트가 3종류 있는데 加算은 전투 중 발생했을 때 CC 회복 효과/増やす는 CC 스탯 자체를 추가하는 걸로 효과가 달라서 오른다/증가한다/+n으로 해뒀어요
4. "戦闘中、[Square_ani2]＋[Down_blink]で、" 쪽은
"전투 중 [Square_ani2]＋[Down_blink] 버튼을 입력했을 때" 가 제일 확실한 설명이긴 한데 그렇게 하면 텍스트가 너무 길어져서 적당히 타협했습니다...
5. "リライズで、"를 "리라이즈하면" 으로 해뒀어요
6. 번역 수정하면서 글씨 납작해질 것 같은 부분 줄바꿈 약간 수정했습니다-