### PR TITLE
귀중품 계열 아이템/무기 일부 텍스트 재작업

### DIFF
--- a/translations/binaries/slps_strings_items_key.json
+++ b/translations/binaries/slps_strings_items_key.json
@@ -502,7 +502,7 @@
             "string": "世界中で発見したものをまとめた[LINE]\n図鑑。[LINE]\n旅の途中で出会った思い出の記録。[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71,
-            "translation": "전 세계에서 발견한 것을 정리한 도감.[LINE]\여행 중에 만난 추억의 기록.[LINE]\n[END]"
+            "translation": "전 세계에서 발견한 것을 정리한 도감.[LINE]\n여행 중에 만난 추억의 기록.[LINE]\n[END]"
         },
         {
             "offset": 1814200,

--- a/translations/binaries/slps_strings_items_key.json
+++ b/translations/binaries/slps_strings_items_key.json
@@ -26,7 +26,7 @@
             "string": "何かの紋章が書かれている石版。[LINE]\n不思議な力を感じる……[LINE]\n[END]",
             "original_bytes_length": 55,
             "available_bytes_size": 55,
-            "translation": "어떤 문장이 새겨진 석판입니다.[LINE]\n신비로운 힘을 느낀다…[LINE]\n[END]"
+            "translation": "어떤 문장이 새겨진 석판.[LINE]\n신비한 힘이 느껴진다…[LINE]\n[END]"
         },
         {
             "offset": 1811112,
@@ -40,7 +40,7 @@
             "string": "モリュウ城の給水装置を[LINE]\n調節するためのバルブ。[LINE]\n[END]",
             "original_bytes_length": 47,
             "available_bytes_size": 47,
-            "translation": "모류성의 급수 장치를[LINE]\n조절하기 위한 밸브입니다.[LINE]\n[END]"
+            "translation": "모류 성의 급수 장치를 조절하는 밸브.[LINE]\n[LINE]\n[END]"
         },
         {
             "offset": 1811184,
@@ -54,7 +54,7 @@
             "string": "完全球体の非常に珍しいレンズ。[LINE]\n富裕層のステータスとして扱われる。[LINE]\n[END]",
             "original_bytes_length": 67,
             "available_bytes_size": 71,
-            "translation": "완전 구형의 매우 희귀한 렌즈입니다.[LINE]\n부유층의 지위로 취급됩니다.[LINE]\n[END]"
+            "translation": "완전한 구형의 매우 희귀한 렌즈.[LINE]\n부유층의 자격으로 취급된다.[LINE]\n[END]"
         },
         {
             "offset": 1811272,
@@ -68,7 +68,7 @@
             "string": "非常に強度の高いレンズ。[LINE]\n軍事用装甲などにも用いられる。[LINE]\n[END]",
             "original_bytes_length": 57,
             "available_bytes_size": 63,
-            "translation": "매우 강도가 높은 렌즈입니다.[LINE]\n군사용 장갑 등에 사용됩니다.[LINE]\n[END]"
+            "translation": "매우 강도가 높은 렌즈.[LINE]\n군사용 장갑판 등에도 사용된다.[LINE]\n[END]"
         },
         {
             "offset": 1811360,
@@ -82,7 +82,7 @@
             "string": "やや珍しい、濃い青色のレンズ。[LINE]\n高価な家具などの飾りに[LINE]\n用いることもある。[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79,
-            "translation": "다소 희귀한, 진한 파란색 렌즈입니다.[LINE]\n비싼 가구 등의 장식에[LINE]\n사용하기도 합니다.[END]"
+            "translation": "꽤 희귀한 짙푸른 색 렌즈.[LINE]\n값비싼 가구 등에[LINE]\n장식으로 사용하기도 한다.[END]"
         },
         {
             "offset": 1811456,
@@ -96,7 +96,7 @@
             "string": "傷のない精錬されたレンズ。[LINE]\n一般的にレンズといえばこれ。[LINE]\n[END]",
             "original_bytes_length": 57,
             "available_bytes_size": 63,
-            "translation": "흠 없는 정련된 렌즈입니다.[LINE]\n일반적으로 렌즈라고 하면 이 것입니다.[LINE]\n[END]"
+            "translation": "흠 없이 정련된 렌즈.[LINE]\n보통 렌즈라고 하면 이걸 뜻한다.[LINE]\n[END]"
         },
         {
             "offset": 1811544,
@@ -110,7 +110,7 @@
             "string": "傷のついたレンズ。[LINE]\n安価ではあるが取引は可能。[LINE]\n[END]",
             "original_bytes_length": 47,
             "available_bytes_size": 47,
-            "translation": "흠이 있는 렌즈입니다.[LINE]\n저렴하지만 거래는 가능합니다.[LINE]\n[END]"
+            "translation": "흠집이 난 렌즈.[LINE]\n헐값이지만 거래할 수는 있다.[LINE]\n[END]"
         },
         {
             "offset": 1811616,
@@ -124,7 +124,7 @@
             "string": "ＥＸダンジョン「アルカナルイン」[LINE]\nに入るための鍵。[LINE]\n[END]",
             "original_bytes_length": 51,
             "available_bytes_size": 55,
-            "translation": "EX 던전「알카나르 인」[LINE]\n에 들어가기 위한 열쇠입니다.[LINE]\n[END]"
+            "translation": "EX 던전 「아르카나 루인」에[LINE]\n들어가기 위한 열쇠.[LINE]\n[END]"
         },
         {
             "offset": 1811688,
@@ -138,7 +138,7 @@
             "string": "集積レンズ砲の出力を確保するため[LINE]\nにカルバレイスの人たちが集めた[LINE]\nレンズ。[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79,
-            "translation": "집적 렌즈 포의 출력을 확보하기 위해[LINE]\n칼바레이스의 사람들이 모은[LINE]\n렌즈입니다.[END]"
+            "translation": "집적 렌즈포의 출력을 확보하기 위해[LINE]\n칼바레이스 사람들이 모은 렌즈.[LINE]\n[END]"
         },
         {
             "offset": 1811792,
@@ -152,7 +152,7 @@
             "string": "集積レンズ砲の出力を確保するため[LINE]\nにアクアヴェイルの人たちが集めた[LINE]\nレンズ。[END]",
             "original_bytes_length": 75,
             "available_bytes_size": 79,
-            "translation": "집적 렌즈 포의 출력을 확보하기 위해[LINE]\n아쿠아베일의 사람들이 모은[LINE]\n렌즈입니다.[END]"
+            "translation": "집적 렌즈포의 출력을 확보하기 위해[LINE]\n아쿠아베일 사람들이 모은 렌즈.[LINE]\n[END]"
         },
         {
             "offset": 1811896,
@@ -166,21 +166,21 @@
             "string": "集積レンズ砲の出力を確保するため[LINE]\nにファンダリアの人たちが集めた[LINE]\nレンズ。[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79,
-            "translation": "집적 렌즈 포의 출력을 확보하기 위해[LINE]\n팬더리아의 사람들이 모은[LINE]\n렌즈입니다.[END]"
+            "translation": "집적 렌즈포의 출력을 확보하기 위해[LINE]\n팬더리아 사람들이 모은 렌즈[LINE]\n[END]"
         },
         {
             "offset": 1812000,
             "string": "[Sign_Key]雪国のレンズ[END]",
             "original_bytes_length": 18,
             "available_bytes_size": 23,
-            "translation": "[Sign_Key]눈나라의 렌즈[END]"
+            "translation": "[Sign_Key]설국의 렌즈[END]"
         },
         {
             "offset": 1812024,
             "string": "集積レンズ砲の出力を確保するため[LINE]\nにフィッツガルドの人たちが集めた[LINE]\nレンズ。[END]",
             "original_bytes_length": 75,
             "available_bytes_size": 79,
-            "translation": "집적 렌즈 포의 출력을 확보하기 위해[LINE]\n피츠가르드의 사람들이 모은[LINE]\n렌즈입니다.[END]"
+            "translation": "집적 렌즈포의 출력을 확보하기 위해[LINE]\n피츠가르드 사람들이 모은 렌즈[LINE]\n[END]"
         },
         {
             "offset": 1812104,
@@ -194,49 +194,49 @@
             "string": "生体金属の原料の青い鉱石。[LINE]\n飛行竜を直すのに十分な量がある。[LINE]\n[END]",
             "original_bytes_length": 61,
             "available_bytes_size": 63,
-            "translation": "생체 금속의 원료인 푸른 광석입니다.[LINE]\n비행룡을 고치는 데 충분한 양이 있습니다.[LINE]\n[END]"
+            "translation": "생체 금속의 원료인 푸른 광석.[LINE]\n비행룡을 수리할 수 있을 정도로 많다.[LINE]\n[END]"
         },
         {
             "offset": 1812192,
             "string": "[Sign_Key]マス・ベルセリウム[END]",
             "original_bytes_length": 24,
             "available_bytes_size": 24,
-            "translation": "[Sign_Key]마스 벨셀리움[END]"
+            "translation": "[Sign_Key]마스 베르셀리움[END]"
         },
         {
             "offset": 1812216,
             "string": "生体金属の原料の青い鉱石。[LINE]\n飛行竜を直すのに必要。[LINE]\n[END]",
             "original_bytes_length": 51,
             "available_bytes_size": 55,
-            "translation": "생체 금속의 원료인 푸른 광석입니다.[LINE]\n비행룡을 고치는 데 필요합니다.[LINE]\n[END]"
+            "translation": "생체 금속의 원료인 푸른 광석.[LINE]\n비행룡을 수리하는 데에 필요하다.[LINE]\n[END]"
         },
         {
             "offset": 1812272,
             "string": "[Sign_Key]ベルセリウム[END]",
             "original_bytes_length": 18,
             "available_bytes_size": 23,
-            "translation": "[Sign_Key]벨셀리움[END]"
+            "translation": "[Sign_Key]베르셀리움[END]"
         },
         {
             "offset": 1812296,
             "string": "鏡面バリアーを中和するための装置。[LINE]\n[LINE]\n[END]",
             "original_bytes_length": 37,
             "available_bytes_size": 39,
-            "translation": "거울 표면 방어막을 중화하기 위한 장치입니다.[LINE]\n[LINE]\n[END]"
+            "translation": "경면 배리어를 중화하기 위한 장치.[LINE]\n[LINE]\n[END]"
         },
         {
             "offset": 1812336,
             "string": "[Sign_Key]鏡面バリアー中和装置[END]",
             "original_bytes_length": 26,
             "available_bytes_size": 31,
-            "translation": "[Sign_Key]거울면 방어막 중화 장치[END]"
+            "translation": "[Sign_Key]경면 배리어 중화 장치[END]"
         },
         {
             "offset": 1812368,
             "string": "ヘルレイオスの扉を[LINE]\n開けるための灰色カードキー。[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55,
-            "translation": "헬레리오스의 문을[LINE]\n열기 위한 회색 카드 키입니다.[LINE]\n[END]"
+            "translation": "헬레이오스의 문을 열기 위한[LINE]\n회색 카드 키.[LINE]\n[END]"
         },
         {
             "offset": 1812424,
@@ -250,7 +250,7 @@
             "string": "ヘルレイオスの扉を[LINE]\n開けるための黄色カードキー。[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55,
-            "translation": "헬레리오스의 문을[LINE]\n열기 위한 노란색 카드 키입니다.[LINE]\n[END]"
+            "translation": "헬레이오스의 문을 열기 위한[LINE]\n노란색 카드 키.[LINE]\n[END]"
         },
         {
             "offset": 1812504,
@@ -264,7 +264,7 @@
             "string": "ヘルレイオスの扉を[LINE]\n開けるための青色カードキー。[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55,
-            "translation": "헬레리오스의 문을[LINE]\n열기 위한 파란색 카드 키입니다.[LINE]\n[END]"
+            "translation": "헬레이오스의 문을 열기 위한[LINE]\n파란색 카드 키.[LINE]\n[END]"
         },
         {
             "offset": 1812584,
@@ -278,7 +278,7 @@
             "string": "ヘルレイオスの扉を[LINE]\n開けるための赤色カードキー。[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55,
-            "translation": "헬레리오스의 문을[LINE]\n열기 위한 빨간색 카드 키입니다.[LINE]\n[END]"
+            "translation": "헬레이오스의 문을 열기 위한[LINE]\n빨간색 카드 키.[LINE]\n[END]"
         },
         {
             "offset": 1812664,
@@ -292,7 +292,7 @@
             "string": "アンスズーンのメインシステムに[LINE]\nエネルギーを供給するユニット。[LINE]\n[END]",
             "original_bytes_length": 63,
             "available_bytes_size": 63,
-            "translation": "안수존의 메인 시스템에[LINE]\n에너지를 공급하는 유닛입니다.[LINE]\n[END]"
+            "translation": "안스준의 메인 시스템에[LINE]\n에너지를 공급하는 유닛.[LINE]\n[END]"
         },
         {
             "offset": 1812752,
@@ -306,7 +306,7 @@
             "string": "ラディスロウの機能を[LINE]\n復活させるための装置。[LINE]\n[END]",
             "original_bytes_length": 45,
             "available_bytes_size": 47,
-            "translation": "라디슬로우의 기능을[LINE]\n복원하기 위한 장치입니다.[LINE]\n[END]"
+            "translation": "라디슬로우의 기능을[LINE]\n복원하기 위한 장치.[LINE]\n[END]"
         },
         {
             "offset": 1812824,
@@ -320,7 +320,7 @@
             "string": "動物の角で作ったラッパ。[LINE]\n海の近くで使うと海竜が呼べる。[LINE]\n[END]",
             "original_bytes_length": 57,
             "available_bytes_size": 63,
-            "translation": "동물의 뿔로 만든 나팔입니다.[LINE]\n바다 근처에서 사용하면 해룡을 부를 수 있습니다.[LINE]\n[END]"
+            "translation": "동물의 뿔로 만든 나팔.[LINE]\n바다 근처에서 사용하면[LINE]\n해룡을 부를 수 있다.[END]"
         },
         {
             "offset": 1812904,
@@ -334,7 +334,7 @@
             "string": "堅い土地を掘り起こすのに使う道具。[LINE]\n先端の両端がくちばしのように[LINE]\nとがっている。[END]",
             "original_bytes_length": 79,
             "available_bytes_size": 79,
-            "translation": "단단한 땅을 파는 데 사용하는 도구입니다.[LINE]\n끝 부분이 부리처럼[LINE]\n뾰족합니다.[END]"
+            "translation": "단단한 땅을 팔 때 쓰는 도구.[LINE]\n양쪽 날 끝이 부리처럼 뾰족하다.[LINE]\n[END]"
         },
         {
             "offset": 1813000,
@@ -348,7 +348,7 @@
             "string": "セインガルドからファンダリアへ[LINE]\n入るために必要な通行証。[LINE]\nこれがないと大変……[END]",
             "original_bytes_length": 77,
             "available_bytes_size": 79,
-            "translation": "세인갈드에서 팬더리아로[LINE]\n들어가기 위해 필요한 통행증입니다.[LINE]\n이게 없으면 큰일입니다…[END]"
+            "translation": "세인가르드에서 팬더리아로[LINE]\n입국하기 위해 필요한 통행증.[LINE]\n이게 없으면 큰일나겠지…[END]"
         },
         {
             "offset": 1813096,
@@ -362,7 +362,7 @@
             "string": "背負えるように改造された大型の箱。[LINE]\nフードストラップを１６個装着可能。[LINE]\n[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71,
-            "translation": "메고 다닐 수 있도록 개조된 대형 상자입니다.[LINE]\n푸드 스트랩을 16개 장착할 수 있습니다.[LINE]\n[END]"
+            "translation": "메고 다닐 수 있게 개조된 대형 상자.[LINE]\n푸드 스트랩을 16개 장착할 수 있다.[LINE]\n[END]"
         },
         {
             "offset": 1813184,
@@ -376,7 +376,7 @@
             "string": "長旅にも安心なリュックサック。[LINE]\nフードストラップを８個装着可能。[LINE]\n[END]",
             "original_bytes_length": 65,
             "available_bytes_size": 71,
-            "translation": "긴 여행에도 안심할 수 있는 배낭입니다.[LINE]\n푸드 스트랩을 8개 장착할 수 있습니다.[LINE]\n[END]"
+            "translation": "긴 여행에도 안심할 수 있는 배낭.[LINE]\n푸드 스트랩을 8개 장착할 수 있다.[LINE]\n[END]"
         },
         {
             "offset": 1813280,
@@ -390,7 +390,7 @@
             "string": "買い物などにも便利な[LINE]\n肩掛けのバッグ。[LINE]\nフードストラップを６個装着可能。[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71,
-            "translation": "쇼핑 등에 유용한[LINE]\n어깨에 메는 가방입니다.[LINE]\n푸드 스트랩을 6개 장착할 수 있습니다.[END]"
+            "translation": "쇼핑할 때도 유용하게 쓸 수 있는[LINE]\n어깨에 메는 가방.[LINE]\n푸드 스트랩을 6개 장착할 수 있다.[END]"
         },
         {
             "offset": 1813376,
@@ -404,7 +404,7 @@
             "string": "自動的に料理が出てくる不思議な袋。[LINE]\nフード補充し忘れに注意しよう！[LINE]\nフードストラップを４個装着可能。[END]",
             "original_bytes_length": 99,
             "available_bytes_size": 103,
-            "translation": "자동으로 요리가 나오는 신기한 주머니입니다.[LINE]\n푸드 보충을 잊지 않도록 주의하세요![LINE]\n푸드 스트랩을 4개 장착할 수 있습니다.[END]"
+            "translation": "자동으로 요리가 나오는 신기한 주머니.[LINE]\n푸드 보충을 잊지 않도록 주의하자![LINE]\n푸드 스트랩을 4개 장착할 수 있다.[END]"
         },
         {
             "offset": 1813504,
@@ -418,7 +418,7 @@
             "string": "かくれた気配を探り当てる占い棒。[LINE]\nフィールド移動中に[R2_ani]ボタンで[LINE]\n起動する。[END]",
             "original_bytes_length": 76,
             "available_bytes_size": 79,
-            "translation": "숨겨진 기척을 탐지하는 점술봉입니다.[LINE]\n필드 이동 중에 [R2_ani]버튼으로[LINE]\n작동합니다.[END]"
+            "translation": "숨겨진 기척을 탐지하는 점술봉.[LINE]\n필드 이동 중 [R2_ani]를 눌러 작동할 수 있다.[LINE]\n[END]"
         },
         {
             "offset": 1813608,
@@ -432,7 +432,7 @@
             "string": "レンズの力で強い熱を発射する指輪。[LINE]\n[Square_ani]ボタンで発射する。[LINE]\n[END]",
             "original_bytes_length": 60,
             "available_bytes_size": 63,
-            "translation": "렌즈의 힘으로 강한 열을 발사하는 반지입니다.[LINE]\n[Square_ani]버튼으로 발사합니다.[LINE]\n[END]"
+            "translation": "렌즈의 힘으로 강한 열을 발사하는 반지.[LINE]\n[Square_ani]를 눌러 발사할 수 있다.[LINE]\n[END]"
         },
         {
             "offset": 1813696,
@@ -446,7 +446,7 @@
             "string": "カスタム設定でモンスター図鑑の[LINE]\nディフィニットストライク表示を[LINE]\n変更できる戦術書。[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87,
-            "translation": "커스텀 설정으로 몬스터 도감의[LINE]\n디피니트 스트라이크 표시를[LINE]\n변경할 수 있는 전술서입니다.[END]"
+            "translation": "커스텀 설정에서 몬스터 도감의[LINE]\n디피니트 스트라이크 표시를[LINE]\n변경할 수 있는 전술서.[END]"
         },
         {
             "offset": 1813808,
@@ -460,7 +460,7 @@
             "string": "移動・攻撃を自分で行う操作[LINE]\n「マニュアル」が術技メニューから[LINE]\n選択可能になる戦術書。[END]",
             "original_bytes_length": 83,
             "available_bytes_size": 87,
-            "translation": "이동・공격을 직접 할 수 있는 조작[LINE]\n「매뉴얼」이 기술 메뉴에서[LINE]\n선택 가능해지는 전술서입니다.[END]"
+            "translation": "이동・공격을 직접 할 수 있는 조작[LINE]\n「매뉴얼」을 기술 메뉴에서[LINE]\n선택할 수 있게 되는 전술서.[END]"
         },
         {
             "offset": 1813920,
@@ -474,7 +474,7 @@
             "string": "ここまでの物語のあらすじを読む事[LINE]\nができる本。[LINE]\n[END]",
             "original_bytes_length": 47,
             "available_bytes_size": 47,
-            "translation": "지금까지의 이야기의 개요를 읽을 수 있는 책입니다.[LINE]\n[END]"
+            "translation": "지금까지 있었던 이야기의[LINE]\n개요를 읽을 수 있는 책.[END]"
         },
         {
             "offset": 1813992,
@@ -488,7 +488,7 @@
             "string": "入手したことのあるアイテムが[LINE]\n載った図鑑。全部集めれば何か[LINE]\nいいことがあるかも……[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87,
-            "translation": "입수한 적이 있는 아이템이[LINE]\n실린 도감입니다. 모두 모으면 뭔가[LINE]\n좋은 일이 있을지도…[END]"
+            "translation": "손에 넣은 아이템이 기록된 도감.[LINE]\n전부 채우면 좋은 일이 있을지도…[LINE]\n[END]"
         },
         {
             "offset": 1814104,
@@ -502,7 +502,7 @@
             "string": "世界中で発見したものをまとめた[LINE]\n図鑑。[LINE]\n旅の途中で出会った思い出の記録。[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71,
-            "translation": "전 세계에서 발견한 것을 모은[LINE]\n도감입니다.[LINE]\n여행 중에 만난 기억의 기록입니다.[END]"
+            "translation": "전 세계에서 발견한 것을 정리한 도감.[LINE]\여행 중에 만난 추억의 기록.[LINE]\n[END]"
         },
         {
             "offset": 1814200,
@@ -516,7 +516,7 @@
             "string": "今まで食べたことのある[LINE]\n料理が載った図鑑。[LINE]\n[END]",
             "original_bytes_length": 43,
             "available_bytes_size": 47,
-            "translation": "지금까지 먹어본[LINE]\n요리가 실린 도감입니다.[LINE]\n[END]"
+            "translation": "지금까지 먹어본 적 있는[LINE]\n요리가 실린 도감.[LINE]\n[END]"
         },
         {
             "offset": 1814272,
@@ -530,7 +530,7 @@
             "string": "今までの戦った敵をまとめた図鑑。[LINE]\n戦闘中[R1_copy]を押した状態で[LINE]\n[Circle_ani2]でも起動できる。[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87,
-            "translation": "지금까지 싸운 적을 모은 도감입니다.[LINE]\n전투 중 [R1_copy]를 누른 상태에서[LINE]\n[Circle_ani2]로도 작동할 수 있습니다.[END]"
+            "translation": "지금까지 싸운 적을 정리한 도감.[LINE]\n전투 중 [R1_copy]를 누른 상태에서[LINE]\n[Circle_ani2]를 눌러도 볼 수 있다.[END]"
         },
         {
             "offset": 1814376,
@@ -544,7 +544,7 @@
             "string": "世界を旅する者には欠かせない地図。[LINE]\nフィールドを移動中、[LINE]\n[R3_ani]ボタンで起動する。[END]",
             "original_bytes_length": 80,
             "available_bytes_size": 80,
-            "translation": "세계를 여행하는 자에게 필수적인 지도입니다.[LINE]\n필드 이동 중에 [R3_ani]버튼으로 작동합니다.[END]"
+            "translation": "세계를 여행하는 사람의 필수품인 지도.[LINE]\n필드 이동 중 [R3_ani]를 눌러도 볼 수 있다.[END]"
         },
         {
             "offset": 1814480,

--- a/translations/binaries/slps_strings_items_weapon.json
+++ b/translations/binaries/slps_strings_items_weapon.json
@@ -3,7 +3,7 @@
         {
             "offset": 1772088,
             "string": "カロテンを豊富に含むにんじん。[LINE]\nバターや油で調理すると[LINE]\n吸収が促進される。[END]",
-            "translation": "카로틴을 풍부하게 함유한 당근.[LINE]\n버터나 기름으로 조리하면[LINE]\n흡수가 촉진된다.[END]",
+            "translation": "카로틴이 풍부한 당근.[LINE]\n버터나 기름으로 요리하면[LINE]\n영양소 흡수율이 높아진다.[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79
         },
@@ -17,77 +17,77 @@
         {
             "offset": 1772184,
             "string": "熱狂的な料理ファンのための[LINE]\n究極のおたま。実際に[LINE]\n料理が美味しくなるかどうかは不明。[END]",
-            "translation": "열광적인 요리팬을 위한[LINE]\n궁극의 주걱. 실제로[LINE]\n요리가 맛있어지는지는 불명.[END]",
+            "translation": "열광적인 요리 팬을 위한 궁극의 국자.[LINE]\n실제로 요리가 맛있어지는지는 불명.[LINE]\n[END]",
             "original_bytes_length": 83,
             "available_bytes_size": 87
         },
         {
             "offset": 1772272,
             "string": "[Sign_Sword]ファナティックおたま[END]",
-            "translation": "[Sign_Sword]파나틱 주걱[END]",
+            "translation": "[Sign_Sword]퍼내틱 국자[END]",
             "original_bytes_length": 26,
             "available_bytes_size": 31
         },
         {
             "offset": 1772304,
             "string": "金持ちの証し！金製のおたま。[LINE]\n調理道具というより飾り用。[LINE]\n[END]",
-            "translation": "부자의 증표! 금제 주걱.[LINE]\n조리도구라기보다 장식용.[LINE]\n[END]",
+            "translation": "부자의 증표! 금제 국자.[LINE]\n조리도구라기보다 장식용.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
         {
             "offset": 1772368,
             "string": "[Sign_Sword]金のおたま[END]",
-            "translation": "[Sign_Sword]금 주걱[END]",
+            "translation": "[Sign_Sword]금 국자[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16
         },
         {
             "offset": 1772384,
             "string": "珍しい銀製のおたま。[LINE]\n銀製品はこまめなお手入れが肝心！[LINE]\n[END]",
-            "translation": "드문 은제 주걱.[LINE]\n은제품은 꼼꼼한 손질이 중요![LINE]\n[END]",
+            "translation": "보기 드문 은제 국자.[LINE]\n은제품은 꼼꼼한 손질이 중요![LINE]\n[END]",
             "original_bytes_length": 55,
             "available_bytes_size": 55
         },
         {
             "offset": 1772440,
             "string": "[Sign_Sword]銀のおたま[END]",
-            "translation": "[Sign_Sword]은 주걱[END]",
+            "translation": "[Sign_Sword]은 국자[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16
         },
         {
             "offset": 1772456,
             "string": "ちょっと高価な銅製のおたま。[LINE]\n銅は熱伝導率が高いのですが……[LINE]\n[END]",
-            "translation": "조금 비싼 구리제 주걱.[LINE]\n구리는 열전도율이 높은데......[LINE]\n[END]",
+            "translation": "좀 비싼 구리 국자.[LINE]\n구리는 열전도율이 높은데......[LINE]\n[END]",
             "original_bytes_length": 61,
             "available_bytes_size": 63
         },
         {
             "offset": 1772520,
             "string": "[Sign_Sword]銅のおたま[END]",
-            "translation": "[Sign_Sword]구리 주걱[END]",
+            "translation": "[Sign_Sword]구리 국자[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16
         },
         {
             "offset": 1772536,
             "string": "どこの家庭にもある一般的なおたま。[LINE]\n叩かれたらそれなりに痛いです。[LINE]\n[END]",
-            "translation": "어느 집에나 있는 일반적인 주걱.[LINE]\n치면 그만큼 아프다.[LINE]\n[END]",
+            "translation": "어느 집에나 있는 평범한 국자.[LINE]\n맞으면 아프다.[LINE]\n[END]",
             "original_bytes_length": 67,
             "available_bytes_size": 71
         },
         {
             "offset": 1772608,
             "string": "[Sign_Sword]鉄のおたま[END]",
-            "translation": "[Sign_Sword]철제 주걱[END]",
+            "translation": "[Sign_Sword]철 국자[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16
         },
         {
             "offset": 1772624,
             "string": "実に含まれる糖分が多い[LINE]\nとうもろこし。[LINE]\n新鮮なうちに食べるほど甘い。[END]",
-            "translation": "열매에 포함된 당분이 많은[LINE]\n옥수수.[LINE]\n신선할 때 먹을수록 달다.[END]",
+            "translation": "알갱이에 당분이 많이 들어있는 옥수수[LINE]\n신선할수록 더 달다.[LINE]\n[END]",
             "original_bytes_length": 67,
             "available_bytes_size": 71
         },
@@ -115,21 +115,21 @@
         {
             "offset": 1772840,
             "string": "撥弦楽器のひとつ。[LINE]\n棹に貼った三弦を撥を用いて奏する。[LINE]\nぺんぺん。[END]",
-            "translation": "박현악기의 하나.[LINE]\n막대에 붙인 세 줄을 박을 사용하여 연주한다.[LINE]\n펀펀.[END]",
+            "translation": "발현악기의 일종.[LINE]\n작은 삼각형 모양의 채로[LINE]\n세 개의 현을 튕겨서 연주한다. 빰빰.[END]",
             "original_bytes_length": 65,
             "available_bytes_size": 71
         },
         {
             "offset": 1772912,
             "string": "[Sign_Sword]三味線[END]",
-            "translation": "[Sign_Sword]삼일전[END]",
+            "translation": "[Sign_Sword]샤미센[END]",
             "original_bytes_length": 12,
             "available_bytes_size": 15
         },
         {
             "offset": 1772928,
             "string": "撥弦楽器のひとつ。[LINE]\n左手の指で弦を押さえて音程を調え、[LINE]\n爪やピックで弦を弾く。[END]",
-            "translation": "박현악기의 하나.[LINE]\n왼손의 손가락으로 줄을 눌러 음정을 맞추고,[LINE]\n손톱이나 픽으로 줄을 친다.[END]",
+            "translation": "발현악기의 일종.[LINE]\n왼손으로 현을 눌러 음정을 맞추고,[LINE]\n손톱이나 픽으로 현을 튕겨서 연주한다.[END]",
             "original_bytes_length": 77,
             "available_bytes_size": 79
         },
@@ -143,7 +143,7 @@
         {
             "offset": 1773024,
             "string": "撥弦楽器のひとつ。[LINE]\n二本一組みに張られた[LINE]\n多数の弦をもつ。[END]",
-            "translation": "박현악기의 하나.[LINE]\n두 개씩 세워진[LINE]\n다수의 줄을 가진다.[END]",
+            "translation": "발현악기의 일종.[LINE]\n두 개의 현이 한 코스를 이루는[LINE]\n복현 구조로 되어 있다.[END]",
             "original_bytes_length": 57,
             "available_bytes_size": 63
         },
@@ -157,7 +157,7 @@
         {
             "offset": 1773104,
             "string": "口琴の一種。[LINE]\nアクアヴェイルで流行した楽器。[LINE]\n針のような鉄を指で弾いて鳴らす。[END]",
-            "translation": "입현의 일종.[LINE]\n아쿠아베일에서 유행한 악기.[LINE]\n바늘처럼 철을 손가락으로 치며 울린다.[END]",
+            "translation": "발현악기의 일종.[LINE]\n커다란 삼각형 모양의 채로[LINE]\n현을 튕겨서 연주한다.[END]",
             "original_bytes_length": 77,
             "available_bytes_size": 79
         },
@@ -171,14 +171,14 @@
         {
             "offset": 1773200,
             "string": "撥弦楽器のひとつ。[LINE]\n鼈甲やセルロイド製の爪で弾いて[LINE]\n演奏する。[END]",
-            "translation": "박현악기의 하나.[LINE]\n거북이 등이나 셀로이드제의 손톱으로[LINE]\n연주한다.[END]",
+            "translation": "발현악기의 일종. 거북이 등껍질이나[LINE]\n셀룰로이드로 만든 픽으로[LINE]\n현을 튕겨서 연주한다.[END]",
             "original_bytes_length": 61,
             "available_bytes_size": 63
         },
         {
             "offset": 1773264,
             "string": "[Sign_Sword]マンドリン[END]",
-            "translation": "[Sign_Sword]만드린[END]",
+            "translation": "[Sign_Sword]만돌린[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16
         },
@@ -199,7 +199,7 @@
         {
             "offset": 1773392,
             "string": "神の兵器と名付けられたナックル。[LINE]\n輝く拳は全ての悪を打ち砕く。[LINE]\n[END]",
-            "translation": "신의 병기로 이름 붙여진 너클.[LINE]\n빛나는 주먹은 모든 악을 부순다.[LINE]\n[END]",
+            "translation": "신의 병기라는 이름이 붙은 너클.[LINE]\n빛나는 주먹은 모든 악을 부순다.[LINE]\n[END]",
             "original_bytes_length": 63,
             "available_bytes_size": 63
         },
@@ -213,7 +213,7 @@
         {
             "offset": 1773480,
             "string": "どこで殴っても敵に致命傷を[LINE]\n与える恐ろしいナックル。[LINE]\n「威力組織」の意味を有する。[END]",
-            "translation": "어디를 때려도 적에게 치명상을[LINE]\n주는 무서운 너클.[LINE]\n「위력조직」의 의미를 가진다.[END]",
+            "translation": "어디를 때려도 적에게[LINE]\n치명상을 입히는 무서운 너클.[LINE]\n이름은 「위력조직」 이라는 뜻.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
@@ -229,7 +229,7 @@
             "string": "悪意を意味するナックル。[LINE]\n角で切り裂き、毒を注いで敵の[LINE]\n動きを麻痺させる凶悪な武器。[END]",
             "original_bytes_length": 83,
             "available_bytes_size": 87,
-            "translation": "악의를 의미하는 너클입니다.[LINE]\n뿔로 베어내고, 독을 주입하여 적의[LINE]\n움직임을 마비시키는 잔인한 무기입니다.[END]"
+            "translation": "악의를 뜻하는 너클[LINE]\n뿔로 꿰뚫은 뒤 독을 주입해[LINE]\n적을 마비시키는 흉악한 무기[END]"
         },
         {
             "offset": 1773680,
@@ -243,7 +243,7 @@
             "string": "伝説に登場する幻想の力を秘めた[LINE]\nナックル。口伝を書物にまとめた[LINE]\n兄弟の名を冠する。[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87,
-            "translation": "전설에 등장하는 환상의 힘을 지닌[LINE]\n너클입니다. 구술로 전해진 내용을 책으로 정리한[LINE]\n형제의 이름을 따릅니다.[END]"
+            "translation": "전설에 나오는 환상의 힘이 깃든 너클.[LINE]\n이야기를 책으로 엮은[LINE]\n형제의 이름이 붙었다.[END]",
         },
         {
             "offset": 1773784,
@@ -255,7 +255,7 @@
         {
             "offset": 1773808,
             "string": "初代チャンピオンが愛用していたと[LINE]\n言われている由緒あるナックル。[LINE]\n[END]",
-            "translation": "초대 챔피언이 애용했다고[LINE]\n말해진 유족 있는 너클.[LINE]\n[END]",
+            "translation": "초대 챔피언이 애용했다는[LINE]\n유서 깊은 너클.[LINE]\n[END]",
             "original_bytes_length": 65,
             "available_bytes_size": 71
         },
@@ -269,7 +269,7 @@
         {
             "offset": 1773904,
             "string": "アクアヴェイルの伝説に登場する、[LINE]\nドラゴンをイメージしたナックル。[LINE]\n鉤爪があり、引掻くのも 有効。[END]",
-            "translation": "아쿠아베일의 전설에 등장하는,[LINE]\n드래곤을 이미지한 너클.[LINE]\n갈고리가 있어, 긁는 것도 효과적.[END]",
+            "translation": "아쿠아베일 전설에 나오는 드래곤을[LINE]\n이미지한 너클. 갈고리가 있어서,[LINE]\n할퀴는 용도로도 쓸 수 있다.[END]",
             "original_bytes_length": 95,
             "available_bytes_size": 95
         },
@@ -283,7 +283,7 @@
         {
             "offset": 1774024,
             "string": "熊の手を模したナックル。[LINE]\n使用されている獣毛は本物で、[LINE]\nちょっと臭い。[END]",
-            "translation": "곰의 손을 모방한 너클.[LINE]\n사용된 수퀄은 진짜로,[LINE]\n조금 냄새난다.[END]",
+            "translation": "곰의 손 모양을 본뜬 너클.[LINE]\n진짜 곰털로 만들어서 조금 냄새가 난다.[LINE]\n[END]",
             "original_bytes_length": 69,
             "available_bytes_size": 71
         },
@@ -297,7 +297,7 @@
         {
             "offset": 1774120,
             "string": "名工ギースの魂がこもった[LINE]\n無二の傑作。きわめて希少価値が[LINE]\n高く、戦士たちの憧れのナックル。[END]",
-            "translation": "명공 기스의 영혼이 담긴[LINE]\n무이의 걸작. 매우 희귀가치가[LINE]\n높아, 전사들의 동경의 너클.[END]",
+            "translation": "명공 기스의 혼이 담긴[LINE]\n둘도 없는 걸작. 매우 희소가치가[LINE]\n높아서 많은 전사가 동경하는 너클.[END]",
             "original_bytes_length": 89,
             "available_bytes_size": 95
         },
@@ -311,7 +311,7 @@
         {
             "offset": 1774240,
             "string": "ダイヤを磨き刃にした美しい[LINE]\nナックル。鋭くて硬いため、[LINE]\nとてつもなく痛い。[END]",
-            "translation": "다이아몬드를 닦아서 칼날로 만든 아름다운[LINE]\n너클. 날카롭고 단단하기 때문에,[LINE]\n엄청나게 아프다.[END]",
+            "translation": "다이아몬드를 연마해 칼날로 만든[LINE]\n아름다운 너클. 날카롭고 단단해서,[LINE]\n엄청나게 아프다.[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79
         },
@@ -325,7 +325,7 @@
         {
             "offset": 1774344,
             "string": "殴るより刺すことに重点を置いた[LINE]\nナックル。針の分リーチが長いので[LINE]\n大振りな人にお勧め。[END]",
-            "translation": "치는 것보다 찌르는 데 중점을 둔[LINE]\n너클. 바늘의 리치가 길어서[LINE]\n큰 휘두르는 사람에게 추천.[END]",
+            "translation": "때리기보다 찌르는 데 중점을 둔 너클.[LINE]\n바늘 길이만큼 리치가 늘어나서[LINE]\n키가 큰 사람에게 추천.[END]",
             "original_bytes_length": 85,
             "available_bytes_size": 87
         },
@@ -353,7 +353,7 @@
         {
             "offset": 1774544,
             "string": "ミスリルを用いて鍛え上げた。[LINE]\nドワーフ族の芸術作品といわれる。[LINE]\n[END]",
-            "translation": "미스릴을 사용하여 닦아낸.[LINE]\n드워프족의 예술작품이라고 한다.[LINE]\n[END]",
+            "translation": "미스릴을 소재로 벼려낸 너클.[LINE]\n드워프족의 예술작품이라고 한다.[LINE]\n[END]",
             "original_bytes_length": 63,
             "available_bytes_size": 63
         },
@@ -367,7 +367,7 @@
         {
             "offset": 1774632,
             "string": "金をふんだんに混ぜて作られた。[LINE]\n別名「豪華な拳」。[LINE]\n[END]",
-            "translation": "금을 풍부하게 섞어 만들어졌다.[LINE]\n별명「화려한 주먹」.[LINE]\n[END]",
+            "translation": "금을 풍부하게 넣어 만든 너클.[LINE]\n일명 「호화로운 주먹」.[LINE]\n[END]",
             "original_bytes_length": 51,
             "available_bytes_size": 55
         },
@@ -381,7 +381,7 @@
         {
             "offset": 1774712,
             "string": "銀細工で装飾されたナックル。[LINE]\n白い輝きが美しい。[LINE]\n[END]",
-            "translation": "은공예로 장식된 너클.[LINE]\n하얀 빛이 아름답다.[LINE]\n[END]",
+            "translation": "은세공으로 장식된 너클.[LINE]\n하얀 빛이 아름답다.[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55
         },
@@ -395,21 +395,21 @@
         {
             "offset": 1774792,
             "string": "さまざまな用途に使われる[LINE]\nチタン製のナックル。[LINE]\n[END]",
-            "translation": "다양한 용도에 사용되는[LINE]\n티탄제의 너클.[LINE]\n[END]",
+            "translation": "다양한 용도로 사용되는[LINE]\n티타늄으로 만든 너클.[LINE]\n[END]",
             "original_bytes_length": 47,
             "available_bytes_size": 47
         },
         {
             "offset": 1774840,
             "string": "[Sign_Sword]チタンナックル[END]",
-            "translation": "[Sign_Sword]티탄 너클[END]",
+            "translation": "[Sign_Sword]티타늄 너클[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
         {
             "offset": 1774864,
             "string": "さまざまな構造物に使われる[LINE]\n鉄製のナックル。[LINE]\n[END]",
-            "translation": "다양한 구조물에 사용되는[LINE]\n철제의 너클.[LINE]\n[END]",
+            "translation": "다양한 구조물에 사용되는[LINE]\n철로 만든 너클.[LINE]\n[END]",
             "original_bytes_length": 45,
             "available_bytes_size": 47
         },
@@ -423,7 +423,7 @@
         {
             "offset": 1774936,
             "string": "いぼがチクチクするものほど新鮮な証。[LINE]\n未熟なうちに収穫するのがポイント。[LINE]\n[END]",
-            "translation": "혹이 따가울수록 신선한 증거.[LINE]\n미숙한 때에 수확하는 것이 포인트.[LINE]\n[END]",
+            "translation": "가시가 따끔할수록 신선하다.[LINE]\n덜 익었을 때 수확하는 게 포인트.[LINE]\n[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79
         },
@@ -437,35 +437,35 @@
         {
             "offset": 1775032,
             "string": "運命を意味する小型弓。[LINE]\n手にした者の望む運命を呼び寄せる。[LINE]\n選ばれた者のみが手にできる。[END]",
-            "translation": "운명을 의미하는 소형 활.[LINE]\n손에 든 자의 바라는 운명을 불러오는.[LINE]\n선택받은 자만이 손에 넣을 수 있다.[END]",
+            "translation": "운명을 의미하는 단궁.[LINE]\n손에 든 자가 바라는 운명을 부른다.[LINE]\n선택받은 자만이 손에 넣을 수 있다.[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87
         },
         {
             "offset": 1775120,
             "string": "[Sign_Sword]フォーチューンアロー[END]",
-            "translation": "[Sign_Sword]포츈 활[END]",
+            "translation": "[Sign_Sword]포춘 애로[END]",
             "original_bytes_length": 26,
             "available_bytes_size": 31
         },
         {
             "offset": 1775152,
             "string": "遥か昔に落ちた隕石から作られた[LINE]\n小型弓。その素材の成分は[LINE]\n解明されていない。[END]",
-            "translation": "아득히 옛날에 떨어진 운석에서 만든[LINE]\n소형 활. 그 소재의 성분은[LINE]\n해명되지 않았다.[END]",
+            "translation": "먼 옛날 떨어진 운석으로 만든 단궁.[LINE]\n그 소재의 성분은 해명되지 않았다.[LINE]\n[END]",
             "original_bytes_length": 75,
             "available_bytes_size": 79
         },
         {
             "offset": 1775232,
             "string": "[Sign_Sword]セレスティアルスター[END]",
-            "translation": "[Sign_Sword]셀레스티얼 스타[END]",
+            "translation": "[Sign_Sword]세레스티아 스타[END]",
             "original_bytes_length": 26,
             "available_bytes_size": 31
         },
         {
             "offset": 1775264,
             "string": "この弓で射抜いた者の魂を吸い上げ[LINE]\n所有者の力にすると言われている。[LINE]\n[END]",
-            "translation": "이 활로 쏜 자의 영혼을 흡수하여[LINE]\n소유자의 힘으로 만든다고 한다.[LINE]\n[END]",
+            "translation": "활에 맞은 자의 영혼을 흡수해[LINE]\n소유자의 힘으로 만든다고 한다.[LINE]\n[END]",
             "original_bytes_length": 67,
             "available_bytes_size": 71
         },
@@ -479,7 +479,7 @@
         {
             "offset": 1775360,
             "string": "必殺必中。稲妻のような速さで[LINE]\n狙った獲物を貫く小型弓。[LINE]\n[END]",
-            "translation": "필살필중. 번개처럼 빠른 속도로[LINE]\n노리는 사냥감을 관통하는 소형 활.[LINE]\n[END]",
+            "translation": "필살필중.[LINE]\n번개처럼 빠르게 사냥감을 꿰뚫는 단궁[LINE]\n[END]",
             "original_bytes_length": 55,
             "available_bytes_size": 55
         },
@@ -493,7 +493,7 @@
         {
             "offset": 1775440,
             "string": "情熱的で美しい女戦士が愛用して[LINE]\nいた弓の小型版。針の穴をも通す[LINE]\nことから、この名がつけられ た。[END]",
-            "translation": "정열적이고 아름다운 여전사가 애용했던[LINE]\n활의 소형판. 바늘 구멍을 통과하는[LINE]\n것에서, 이 이름이 붙여졌다.[END]",
+            "translation": "정열적이고 아름다운 여전사가 애용한[LINE]\n활의 소형판. 바늘구멍도 꿰뚫는다고[LINE]\n이런 이름이 붙었다.[END]",
             "original_bytes_length": 93,
             "available_bytes_size": 95
         },
@@ -507,224 +507,224 @@
         {
             "offset": 1775568,
             "string": "伝説に登場する幻想の力を秘めた[LINE]\n小型弓。口伝を書物にまとめた[LINE]\n兄弟の名を冠する。[END]",
-            "translation": "전설에 등장하는 환상의 힘을 감춘[LINE]\n소형 활. 구전을 서적으로 정리한[LINE]\n형제의 이름을 달다.[END]",
+            "translation": "전설에 나오는 환상의 힘이 깃든 단궁.[LINE]\n이야기를 책으로 엮은[LINE]\n형제의 이름이 붙었다.[END]",
             "original_bytes_length": 79,
             "available_bytes_size": 79
         },
         {
             "offset": 1775648,
             "string": "[Sign_Sword]グリムアロー[END]",
-            "translation": "[Sign_Sword]그림 활[END]",
+            "translation": "[Sign_Sword]그림 애로[END]",
             "original_bytes_length": 18,
             "available_bytes_size": 23
         },
         {
             "offset": 1775672,
             "string": "無敵を誇った弓兵が使用していた、[LINE]\nと言われる弓の小型版。[LINE]\n別名「狂戦士の弓」小型版。[END]",
-            "translation": "무적을 자랑했던 궁병이 사용했다고[LINE]\n말해진 활의 소형판.[LINE]\n별명「광전사의 활」 소형판.[END]",
+            "translation": "무적의 궁수가 사용했다는 활의 소형판.[LINE]\n일명 「광전사의 활」 소형판이다.[LINE]\n[END]",
             "original_bytes_length": 83,
             "available_bytes_size": 87
         },
         {
             "offset": 1775760,
             "string": "[Sign_Sword]ベルセルクアロー[END]",
-            "translation": "[Sign_Sword]베르세르크 활[END]",
+            "translation": "[Sign_Sword]베르세르크 애로[END]",
             "original_bytes_length": 22,
             "available_bytes_size": 23
         },
         {
             "offset": 1775784,
             "string": "三日月の形を模した小型弓。[LINE]\nその美しさに獣たちも動きを止める。[LINE]\nと、言われている。[END]",
-            "translation": "초승달 모양을 모방한 소형 활.[LINE]\n그 아름다움에 짐승들도 움직임을 멈춘다.[LINE]\n라고 말해진다.[END]",
+            "translation": "초승달 모양을 본뜬 단궁.[LINE]\n그 아름다움에 동물들도[LINE]\n움직임을 멈춘다고 한다.[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87
         },
         {
             "offset": 1775872,
             "string": "[Sign_Sword]クレセントアロー[END]",
-            "translation": "[Sign_Sword]크레센트 활[END]",
+            "translation": "[Sign_Sword]크레센트 애로[END]",
             "original_bytes_length": 22,
             "available_bytes_size": 23
         },
         {
             "offset": 1775896,
             "string": "エルフ族が愛用したと言われている[LINE]\n小型弓。羽のように軽い。[LINE]\n[END]",
-            "translation": "엘프족이 애용했다고 한[LINE]\n소형 활. 날개처럼 가볍다.[LINE]\n[END]",
+            "translation": "엘프족이 애용했다는 단궁.[LINE]\n깃털처럼 가볍다.[LINE]\n[END]",
             "original_bytes_length": 59,
             "available_bytes_size": 63
         },
         {
             "offset": 1775960,
             "string": "[Sign_Sword]エルヴンアロー[END]",
-            "translation": "[Sign_Sword]엘븐 활[END]",
+            "translation": "[Sign_Sword]엘븐 애로[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
         {
             "offset": 1775984,
             "string": "全てのパーツを異なった木材で[LINE]\n組み合わせた小型弓。[LINE]\n[END]",
-            "translation": "모든 부품을 다른 나무재료로[LINE]\n조합한 소형 활.[LINE]\n[END]",
+            "translation": "모든 부품을 다른 종류의 목재로[LINE]\n조립한 단궁.[LINE]\n[END]",
             "original_bytes_length": 51,
             "available_bytes_size": 55
         },
         {
             "offset": 1776040,
             "string": "[Sign_Sword]クレインアロー[END]",
-            "translation": "[Sign_Sword]크레인 활[END]",
+            "translation": "[Sign_Sword]크레인 애로[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
         {
             "offset": 1776064,
             "string": "名工ギースの魂がこもった[LINE]\n無二の傑作。きわめて希少価値が[LINE]\n高く、戦士たちの憧れの小型弓。[END]",
-            "translation": "명공 기스의 영혼이 담긴[LINE]\n무이의 걸작. 매우 희귀가치가[LINE]\n높아, 전사들의 동경의 소형 활.[END]",
+            "translation": "명공 기스의 혼이 담긴[LINE]\n둘도 없는 걸작. 매우 희소가치가[LINE]\n높아서 많은 전사가 동경하는 단궁.[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87
         },
         {
             "offset": 1776152,
             "string": "[Sign_Sword]レアアロー[END]",
-            "translation": "[Sign_Sword]레어 활[END]",
+            "translation": "[Sign_Sword]레어 애로[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16
         },
         {
             "offset": 1776168,
             "string": "鷹の爪を模した弧を描いた小型弓。[LINE]\n天高く飛ぶ鳥も射ぬけると[LINE]\n言われている。[END]",
-            "translation": "매의 발톱을 모방한 호를 그린 소형 활.[LINE]\n하늘 높이 날아가는 새도 관통한다고[LINE]\n말해진다.[END]",
+            "translation": "매의 발톱을 본뜬 원호 모양 단궁.[LINE]\n하늘 높이 나는 새도[LINE]\n꿰뚫을 수 있다고 한다.[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79
         },
         {
             "offset": 1776248,
             "string": "[Sign_Sword]グリフィンアロー[END]",
-            "translation": "[Sign_Sword]그리핀 활[END]",
+            "translation": "[Sign_Sword]그리핀 애로[END]",
             "original_bytes_length": 22,
             "available_bytes_size": 23
         },
         {
             "offset": 1776272,
             "string": "一撃必中。[LINE]\n暗殺に特化された小型弓。[LINE]\n[END]",
-            "translation": "일격필중.[LINE]\n암살에 특화된 소형 활.[LINE]\n[END]",
+            "translation": "일격필중.[LINE]\n암살에 특화된 단궁.[LINE]\n[END]",
             "original_bytes_length": 37,
             "available_bytes_size": 39
         },
         {
             "offset": 1776312,
             "string": "[Sign_Sword]キラーアロー[END]",
-            "translation": "[Sign_Sword]킬러 활[END]",
+            "translation": "[Sign_Sword]킬러 보우[END]",
             "original_bytes_length": 18,
             "available_bytes_size": 23
         },
         {
             "offset": 1776336,
             "string": "その名の通り戦闘に特化した小型弓。[LINE]\n強度があり、敵の攻撃を受けても[LINE]\n歪みにくい。[END]",
-            "translation": "그 이름 그대로 전투에 특화된 소형 활.[LINE]\n강도가 있어, 적의 공격을 받아도[LINE]\n왜곡되기 어렵다.[END]",
+            "translation": "그 이름 그대로 전투에 특화된 단궁.[LINE]\n강도가 높아 적의 공격을 받아도[LINE]\n잘 뒤틀리지 않는다.[END]",
             "original_bytes_length": 79,
             "available_bytes_size": 79
         },
         {
             "offset": 1776416,
             "string": "[Sign_Sword]バトルアロー[END]",
-            "translation": "[Sign_Sword]전투 활[END]",
+            "translation": "[Sign_Sword]배틀 애로[END]",
             "original_bytes_length": 18,
             "available_bytes_size": 23
         },
         {
             "offset": 1776440,
             "string": "猟師が好んで使う弓の小型版。[LINE]\n安価な割りに性能は高い。[LINE]\n[END]",
-            "translation": "사냥꾼이 선호하여 사용하는 활의 소형판.[LINE]\n저렴한 가격에 성능은 높다.[LINE]\n[END]",
+            "translation": "사냥꾼이 애용하는 활의 소형판.[LINE]\n저렴한 가격에 비해 성능이 좋다.[LINE]\n[END]",
             "original_bytes_length": 55,
             "available_bytes_size": 55
         },
         {
             "offset": 1776496,
             "string": "[Sign_Sword]ハンターアロー[END]",
-            "translation": "[Sign_Sword]사냥꾼 활[END]",
+            "translation": "[Sign_Sword]헌터 애로[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
         {
             "offset": 1776520,
             "string": "ミスリルを用いて鍛え上げた小型弓。[LINE]\nドワーフ族の芸術作品といわれる。[LINE]\n[END]",
-            "translation": "미스릴을 사용하여 닦아낸 소형 활.[LINE]\n드워프족의 예술작품이라고 한다.[LINE]\n[END]",
+            "translation": "미스릴을 소재로 벼려낸 단궁.[LINE]\n드워프족의 예술작품이라고 한다.[LINE]\n[END]",
             "original_bytes_length": 69,
             "available_bytes_size": 71
         },
         {
             "offset": 1776592,
             "string": "[Sign_Sword]ミスリルアロー[END]",
-            "translation": "[Sign_Sword]미스릴 활[END]",
+            "translation": "[Sign_Sword]미스릴 애로[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
         {
             "offset": 1776616,
             "string": "８割が金で作られた小型弓。[LINE]\n別名「豪華な小型弓」。[LINE]\n[END]",
-            "translation": "8할이 금으로 만들어진 소형 활.[LINE]\n별명「화려한 소형 활」.[LINE]\n[END]",
+            "translation": "8할이 금으로 만들어진 단궁.[LINE]\n일명 「호화로운 단궁」.[LINE]\n[END]",
             "original_bytes_length": 51,
             "available_bytes_size": 55
         },
         {
             "offset": 1776672,
             "string": "[Sign_Sword]ゴールドアロー[END]",
-            "translation": "[Sign_Sword]금 활[END]",
+            "translation": "[Sign_Sword]골드 애로[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
         {
             "offset": 1776696,
             "string": "銀細工で装飾された小型弓。[LINE]\n白い輝きが美しい。[LINE]\n[END]",
-            "translation": "은공예로 장식된 소형 활.[LINE]\n하얀 빛이 아름답다.[LINE]\n[END]",
+            "translation": "은세공으로 장식된 단궁.[LINE]\n하얀 빛이 아름답다.[LINE]\n[END]",
             "original_bytes_length": 47,
             "available_bytes_size": 47
         },
         {
             "offset": 1776744,
             "string": "[Sign_Sword]シルバーアロー[END]",
-            "translation": "[Sign_Sword]은 활[END]",
+            "translation": "[Sign_Sword]실버 애로[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
         {
             "offset": 1776768,
             "string": "さまざまな用途に使われる、[LINE]\nチタン製の小型弓。[LINE]\n[END]",
-            "translation": "다양한 용도에 사용되는,[LINE]\n티탄제의 소형 활.[LINE]\n[END]",
+            "translation": "다양한 용도로 사용되는[LINE]\n티타늄으로 만든 단궁.[LINE]\n[END]",
             "original_bytes_length": 47,
             "available_bytes_size": 47
         },
         {
             "offset": 1776816,
             "string": "[Sign_Sword]チタンアロー[END]",
-            "translation": "[Sign_Sword]티탄 활[END]",
+            "translation": "[Sign_Sword]티타늄 애로[END]",
             "original_bytes_length": 18,
             "available_bytes_size": 23
         },
         {
             "offset": 1776840,
             "string": "鉄に炭素を混ぜてできる合金、[LINE]\n鋼製の小型弓。[LINE]\n[END]",
-            "translation": "철에 탄소를 섞어 만들 수 있는 합금,[LINE]\n강철제의 소형 활.[LINE]\n[END]",
+            "translation": "철에 탄소를 첨가한 합금인[LINE]\n강철로 만든 단궁.[LINE]\n[END]",
             "original_bytes_length": 45,
             "available_bytes_size": 47
         },
         {
             "offset": 1776888,
             "string": "[Sign_Sword]スチールアロー[END]",
-            "translation": "[Sign_Sword]강철 활[END]",
+            "translation": "[Sign_Sword]스틸 애로[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23
         },
         {
             "offset": 1776912,
             "string": "木製の小型弓。[LINE]\n初心者用の弓として広く扱われる。[LINE]\n[END]",
-            "translation": "목재로 만든 소형 활.[LINE]\n초보자용 활로 널리 사용된다.[LINE]\n[END]",
+            "translation": "목재로 만든 단궁.[LINE]\n초보자용으로 널리 사용된다.[LINE]\n[END]",
             "original_bytes_length": 49,
             "available_bytes_size": 55
         },
         {
             "offset": 1776968,
             "string": "[Sign_Sword]ウッドアロー[END]",
-            "translation": "[Sign_Sword]나무 활[END]",
+            "translation": "[Sign_Sword]우드 애로[END]",
             "original_bytes_length": 18,
             "available_bytes_size": 23
         },
@@ -759,7 +759,7 @@
         {
             "offset": 1777184,
             "string": "三日月型の幅広い斧頭を持つ戦斧。[LINE]\n敵を切断するのに特化している。[LINE]\n[END]",
-            "translation": "초승달 모양의 넓은 도끼머리를 가진 전투 도끼.[LINE]\n적을 절단하는 데 특화되어 있다.[LINE]\n[END]",
+            "translation": "초승달 모양의[LINE]\n넓은 도끼머리를 가진 전투 도끼..[LINE]\n적을 절단하는 데 특화되어 있다.[END]",
             "original_bytes_length": 65,
             "available_bytes_size": 71
         },
@@ -801,7 +801,7 @@
         {
             "offset": 1777472,
             "string": "タフレンズが埋め込まれた[LINE]\n半月型の斧。豪華な作りだが[LINE]\n切れ味は鋭い。[END]",
-            "translation": "터프 렌즈가 박혀 있는[LINE]\n반달 모양의 도끼. 호화스러운 외형을 하고 있지만[LINE]\n매우 날카롭다.[END]",
+            "translation": "터프 렌즈가 박혀 있는 반달 모양 도끼.[LINE]\n호화스러운 외형을 하고 있지만[LINE]\n매우 날카롭다.[END]",
             "original_bytes_length": 67,
             "available_bytes_size": 71
         },
@@ -829,7 +829,7 @@
         {
             "offset": 1777648,
             "string": "金属で強化することで[LINE]\n強度を上げた斧。[LINE]\n日常の道具としても使用可能。[END]",
-            "translation": "금속으로 강화해[LINE]\n강도를 높인 도끼.[LINE]\n생활도구로도 사용할 수 있다..[END]",
+            "translation": "금속으로 강화해[LINE]\n강도를 높인 도끼.[LINE]\n생활도구로도 사용할 수 있다.[END]",
             "original_bytes_length": 67,
             "available_bytes_size": 71
         },
@@ -843,7 +843,7 @@
         {
             "offset": 1777736,
             "string": "三日月型の斧頭が特徴の戦斧。[LINE]\n少ない金属で作ることが可能な斧。[LINE]\n[END]",
-            "translation": "초승달 모양의 도끼머리가 특징인 전투 도끼.[LINE]\n적은 금속으로 만들 수 있다.[LINE]\n[END]",
+            "translation": "초승달 모양의 도끼머리가[LINE]\n특징인 전투 도끼.[LINE]\n적은 금속으로 만들 수 있다.[END]",
             "original_bytes_length": 63,
             "available_bytes_size": 63
         },
@@ -857,7 +857,7 @@
         {
             "offset": 1777816,
             "string": "伝説に登場する幻想の力を秘めた斧。[LINE]\n口伝を書物にまとめた兄弟の名を[LINE]\n冠する。[END]",
-            "translation": "전설 속에 등장하는 환상의 힘이 깃든 도끼.[LINE]\n이야기를 책으로 엮은 형제의 이름이[LINE]\n붙었다.[END]",
+            "translation": "전설에 나오는 환상의 힘이 깃든 도끼.[LINE]\n이야기를 책으로 엮은[LINE]\n형제의 이름이 붙었다.[END]",
             "original_bytes_length": 75,
             "available_bytes_size": 79
         },
@@ -1039,7 +1039,7 @@
         {
             "offset": 1779120,
             "string": "この斧を初めて見たキコリが、[LINE]\n「グレートだ！」と叫んだことから[LINE]\nこの名がついた。切れ味も抜 群。[END]",
-            "translation": "이 도끼를 처음 본 나무꾼이,[LINE]\n「그레이트다!」라고 외쳐서[LINE]\n이런 이름이 붙었다. 날카로움도 그레이트다.[END]",
+            "translation": "이 도끼를 처음 본 나무꾼이, 「그레이트다!」[LINE]\n라고 외쳐서 이런 이름이 붙었다.[LINE]\n날카로움도 그레이트다.[END]",
             "original_bytes_length": 93,
             "available_bytes_size": 95
         },

--- a/translations/binaries/slps_strings_items_weapon.json
+++ b/translations/binaries/slps_strings_items_weapon.json
@@ -157,14 +157,14 @@
         {
             "offset": 1773104,
             "string": "口琴の一種。[LINE]\nアクアヴェイルで流行した楽器。[LINE]\n針のような鉄を指で弾いて鳴らす。[END]",
-            "translation": "발현악기의 일종.[LINE]\n커다란 삼각형 모양의 채로[LINE]\n현을 튕겨서 연주한다.[END]",
+            "translation": "발현악기의 일종.[LINE]\n아쿠아베일에서 유행한 악기.[LINE]\n세모난 채로 현을 튕겨 연주한다.[END]",
             "original_bytes_length": 77,
             "available_bytes_size": 79
         },
         {
             "offset": 1773184,
             "string": "[Sign_Sword]琵琶[END]",
-            "translation": "[Sign_Sword]비와[END]",
+            "translation": "[Sign_Sword]비파[END]",
             "original_bytes_length": 10,
             "available_bytes_size": 15
         },

--- a/translations/binaries/slps_strings_items_weapon.json
+++ b/translations/binaries/slps_strings_items_weapon.json
@@ -759,7 +759,7 @@
         {
             "offset": 1777184,
             "string": "三日月型の幅広い斧頭を持つ戦斧。[LINE]\n敵を切断するのに特化している。[LINE]\n[END]",
-            "translation": "초승달 모양의[LINE]\n넓은 도끼머리를 가진 전투 도끼..[LINE]\n적을 절단하는 데 특화되어 있다.[END]",
+            "translation": "초승달 모양의[LINE]\n넓은 도끼머리를 가진 전투 도끼.[LINE]\n적을 절단하는 데 특화되어 있다.[END]",
             "original_bytes_length": 65,
             "available_bytes_size": 71
         },


### PR DESCRIPTION
아이템 파일 몇개가 이미 풀리퀘 올라와 있던 것 같기도 한데요...
일단 지금은 다 병합된 것 같아서 잠깐 할 수 있는 만큼 해뒀습니다

무기는 저번에 올렸던 이슈 부분 다른 무기 전부 해둔 것+도끼 줄바꿈 이상한 부분만 약간 수정한 건데요

https://github.com/ToD-DC-Kor/kor-patch/issues/438#issuecomment-2352271719
여기 코멘트의

> 비와 : 구금의 일종. 아쿠아베일에서 유행하는 악기. 바늘처럼 생긴 금속을 손가락으로 튕겨서 연주한다.
(아이템 이름인 琵琶는 비파인데 아쿠아베일이면 일본이고 일본 비파는 그냥 비와라고 쓰는 것 같아서 놔뒀어요.
그런데 설명의 口琴은 보통 구금, 주즈하프인데 이쪽은 보통 입에 물고 연주하는 악기인데요
아이템 이미지는 그냥 비파라서 설명하고 이미지하고 전혀 안 맞는 문제가 있습니다.
설명 중 바늘처럼 생겼다는 내용도 있어서(비와에 쓰는 채는 삼각형으로 바늘 모양이 아니고 보통 금속도 아닙니다) 아마도 口琴를 口琵琶라고 썼다가 일반 琵琶와 혼동이 생겨서 이렇게 된 게 아닌가 싶네요.
일단 일반적 비파에 맞는 설명과 원문에 맞는 설명 2종류 전부 써뒀습니다.)

비파는 일단 이미지인 그냥 비파 맞춰서 설명 써둔 건데 진짜 어떻게 해야 좋을까요...?