### PR TITLE
음식 재작업 및 강초래 텍스트 수정

### DIFF
--- a/translations/binaries/battle_tutorial_strings.json
+++ b/translations/binaries/battle_tutorial_strings.json
@@ -922,7 +922,7 @@
             "string": "剛招来[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "강소환[END]"
+            "translation": "강초래[END]"
         },
         {
             "offset": 246880,

--- a/translations/binaries/slps_strings_items_food.json
+++ b/translations/binaries/slps_strings_items_food.json
@@ -12,21 +12,21 @@
             "string": "コラボ深[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 심층[END]"
+            "translation": "콜라보 심각한[END]"
         },
         {
             "offset": 1803304,
             "string": "深[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "심[END]"
+            "translation": "심각한[END]"
         },
         {
             "offset": 1803312,
             "string": "闇鍋が出るストラップ。[LINE]\n何が入っているのかわからない！[LINE]\n食べる時は暗闇で。[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79,
-            "translation": "어둠 전골이 나오는 스트랩입니다.[LINE]\n무엇이 들어있는지 알 수 없습니다![LINE]\n먹을 때는 어둠 속에서.[END]"
+            "translation": "어둠 전골이 나오는 스트랩.[LINE]\n뭐가 들었는지 전혀 모르겠어![LINE]\n먹을 때는 어둠 속에서.[END]"
         },
         {
             "offset": 1803392,
@@ -40,7 +40,7 @@
             "string": "究極暗黒鍋[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "궁극의 암흑 냄비[END]"
+            "translation": "궁극의 암흑 전골[END]"
         },
         {
             "offset": 1803424,
@@ -61,7 +61,7 @@
             "string": "闇丼が出るストラップ。[LINE]\n様々なものがつっこまれた恐怖の丼。[LINE]\nまずい日もあれば美味い日もある？[END]",
             "original_bytes_length": 91,
             "available_bytes_size": 95,
-            "translation": "어둠 덮밥이 나오는 스트랩입니다.[LINE]\n여러 가지가 섞인 무서운 덮밥입니다.[LINE]\n맛없는 날도 있고 맛있는 날도 있나요?[END]"
+            "translation": "어둠 덮밥이 나오는 스트랩.[LINE]\n이것저것 뒤섞인 무서운 덮밥.[LINE]\n맛없는 날도 있고 맛있는 날도 있겠지?[END]"
         },
         {
             "offset": 1803544,
@@ -82,21 +82,21 @@
             "string": "コラボ四[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 사[END]"
+            "translation": "콜라보 완전[END]"
         },
         {
             "offset": 1803592,
             "string": "四[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "사[END]"
+            "translation": "완전[END]"
         },
         {
             "offset": 1803600,
             "string": "半生ケバブが出るストラップ。[LINE]\nお肉はしっかり焼いてください。[LINE]\nお腹が痛くなりませんように……[END]",
             "original_bytes_length": 91,
             "available_bytes_size": 95,
-            "translation": "덜 익은 케밥이 나오는 스트랩입니다.[LINE]\n고기는 잘 익혀주세요.[LINE]\n배가 아프지 않기를…[END]"
+            "translation": "덜 익은 케밥이 나오는 스트랩.[LINE]\n고기는 확실히 익히자.[LINE]\n배가 아프지 않기를…[END]"
         },
         {
             "offset": 1803696,
@@ -117,35 +117,35 @@
             "string": "コラボ懐か[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 그리움[END]"
+            "translation": "콜라보 퍼진[END]"
         },
         {
             "offset": 1803736,
             "string": "懐か[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "그리움[END]"
+            "translation": "퍼진[END]"
         },
         {
             "offset": 1803744,
             "string": "しなしなブリトーが出るストラップ。[LINE]\nだいぶ時間が過ぎちゃった？[LINE]\n溶けて固くなったチーズが悲しい。[END]",
             "original_bytes_length": 95,
             "available_bytes_size": 95,
-            "translation": "다 녹은 브리또가 나오는 스트랩입니다.[LINE]\n꽤 시간이 지났나요?[LINE]\n녹아서 딱딱해진 치즈가 슬프네요.[END]"
+            "translation": "눅눅한 부리토가 나오는 스트랩.[LINE]\n만들고 나서 꽤 오래 지났나?[LINE]\n녹았다가 굳은 치즈의 애처로운 맛.[END]"
         },
         {
             "offset": 1803840,
             "string": "[Sign_3]しなしなブリトー[END]",
             "original_bytes_length": 22,
             "available_bytes_size": 23,
-            "translation": "[Sign_3]다 녹은 브리또[END]"
+            "translation": "[Sign_3]눅눅한 부리토[END]"
         },
         {
             "offset": 1803864,
             "string": "こんがりドッグ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "바삭한 핫도그[END]"
+            "translation": "노릇노릇 핫도그[END]"
         },
         {
             "offset": 1803880,
@@ -166,7 +166,7 @@
             "string": "炭ドッグが出るストラップ。[LINE]\n焼きすぎた！すっかり焦げた[LINE]\nソーセージは苦い味がした。[END]",
             "original_bytes_length": 81,
             "available_bytes_size": 87,
-            "translation": "탄 핫도그가 나오는 스트랩입니다.[LINE]\n너무 구워졌어요! 완전히 타버린[LINE]\n소시지는 쓴맛이 났어요.[END]"
+            "translation": "탄 핫도그가 나오는 스트랩.[LINE]\n너무 구웠어! 완전히 탔어![LINE]\n소세지에서 쓴 맛이 난다.[END]"
         },
         {
             "offset": 1803992,
@@ -201,7 +201,7 @@
             "string": "圧縮ハンバーガーが出るストラップ。[LINE]\n誰かのお尻の下敷きになったに違い[LINE]\nない。食べやすくはなりました。[END]",
             "original_bytes_length": 99,
             "available_bytes_size": 103,
-            "translation": "압축 햄버거가 나오는 스트랩입니다.[LINE]\n누군가의 엉덩이로 짓눌렸던 것[LINE]\n같아요. 먹기 편해졌습니다.[END]"
+            "translation": "압축 햄버거가 나오는 스트랩.[LINE]\n누가 엉덩이로 깔아뭉갠 게 분명하다.[LINE]\n먹기 편해지긴 했다.[END]"
         },
         {
             "offset": 1804152,
@@ -222,28 +222,28 @@
             "string": "コラボパサ[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 파사[END]"
+            "translation": "콜라보 퍼석퍼석[END]"
         },
         {
             "offset": 1804208,
             "string": "パサ[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "파사[END]"
+            "translation": "퍼석퍼석[END]"
         },
         {
             "offset": 1804216,
             "string": "パサパサンドイッチが出るストラップ。[LINE]\nなるべく早くに食べましょう。[LINE]\n喉につまってしょうがない。[END]",
             "original_bytes_length": 93,
             "available_bytes_size": 95,
-            "translation": "퍼석퍼석 샌드위치가 나오는 스트랩입니다.[LINE]\n가능한 빨리 먹어야 해요.[LINE]\n목에 걸려서 곤란해요.[END]"
+            "translation": "바싹 마른 샌드위치가 나오는 스트랩.[LINE]\n가능한 빨리 먹자.[LINE]\n목이 막히지만 어쩔 수 없다.[END]"
         },
         {
             "offset": 1804312,
             "string": "[Sign_3]パサパサンドイッチ[END]",
             "original_bytes_length": 24,
             "available_bytes_size": 24,
-            "translation": "[Sign_3]퍼석퍼석 샌드위치[END]"
+            "translation": "[Sign_3]바싹 마른 샌드위치[END]"
         },
         {
             "offset": 1804336,
@@ -257,21 +257,21 @@
             "string": "コラボ目がチ[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 눈이 찌[END]"
+            "translation": "따끔따끔[END]"
         },
         {
             "offset": 1804368,
             "string": "目がチ[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "눈이 찌[END]"
+            "translation": "따끔따끔[END]"
         },
         {
             "offset": 1804376,
             "string": "カチカチおにぎりが出るストラップ。[LINE]\n歯が弱い人は要注意。[LINE]\n顎が鍛えられます。[END]",
             "original_bytes_length": 75,
             "available_bytes_size": 79,
-            "translation": "딱딱한 주먹밥이 나오는 스트랩입니다.[LINE]\n치아가 약한 사람은 주의하세요.[LINE]\n턱이 단련됩니다.[END]"
+            "translation": "딱딱한 주먹밥이 나오는 스트랩.[LINE]\n이빨이 약한 사람은 주의할 것.[LINE]\n턱이 단련된다.[END]"
         },
         {
             "offset": 1804456,
@@ -292,21 +292,21 @@
             "string": "コラボウ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 우[END]"
+            "translation": "콜라보 엄[END]"
         },
         {
             "offset": 1804512,
             "string": "ウ[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "우[END]"
+            "translation": "엄[END]"
         },
         {
             "offset": 1804520,
             "string": "マーボーカレーが出るストラップ。[LINE]\n軍に伝わる秘伝の味。二つの辛味が[LINE]\n織り成す究極のハーモニー！[END]",
             "original_bytes_length": 93,
             "available_bytes_size": 95,
-            "translation": "마파 카레가 나오는 스트랩입니다.[LINE]\n군에서 전해지는 비전의 맛. 두 가지 매운맛이[LINE]\n어우러지는 궁극의 하모니입니다![END]"
+            "translation": "마파 카레가 나오는 스트랩.[LINE]\n군에 전해지는 비밀스러운 맛.[LINE]\n두 매운 맛이 자아낸 궁극의 하모니![END]"
         },
         {
             "offset": 1804616,
@@ -320,28 +320,28 @@
             "string": "みそ田楽[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "된장 단각[END]"
+            "translation": "된장 꼬치구이[END]"
         },
         {
             "offset": 1804656,
             "string": "コラボあわせ[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 조화[END]"
+            "translation": "콜라보 모둠[END]"
         },
         {
             "offset": 1804672,
             "string": "あわせ[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "조화[END]"
+            "translation": "모둠[END]"
         },
         {
             "offset": 1804680,
             "string": "みそおでんが出るストラップ。[LINE]\n甘みのある上質な味噌たれが口の中[LINE]\nで染み渡る。お酒の共にも最適です。[END]",
             "original_bytes_length": 97,
             "available_bytes_size": 103,
-            "translation": "된장 오뎅이 나오는 스트랩입니다.[LINE]\n단맛이 있는 고급 된장 소스가 입안에[LINE]\n스며듭니다. 술안주로도 최적입니다.[END]"
+            "translation": "된장 오뎅이 나오는 스트랩.[LINE]\n달콤한 고급 된장 양념의 맛이[LINE]\n입 안에 스며든다. 술안주로 최고.[END]"
         },
         {
             "offset": 1804784,
@@ -362,21 +362,21 @@
             "string": "コラボ親[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 부모[END]"
+            "translation": "콜라보 대박[END]"
         },
         {
             "offset": 1804840,
             "string": "親[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "부모[END]"
+            "translation": "대박[END]"
         },
         {
             "offset": 1804848,
             "string": "まんぼうの串焼きが出るストラップ。[LINE]\n美味しく食べる事が大事です。[LINE]\n[END]",
             "original_bytes_length": 65,
             "available_bytes_size": 71,
-            "translation": "개복치 꼬치구이가 나오는 스트랩입니다.[LINE]\n맛있게 먹는 것이 중요합니다.[LINE]\n[END]"
+            "translation": "개복치 꼬치구이가 나오는 스트랩.[LINE]\n맛있게 먹는 것이 중요.[LINE]\n[END]"
         },
         {
             "offset": 1804920,
@@ -411,42 +411,42 @@
             "string": "魚鍋が出るストラップ。[LINE]\n魚がメインの鍋。魚の出汁がたまり[LINE]\nません。残りは雑炊にどうぞ。[END]",
             "original_bytes_length": 85,
             "available_bytes_size": 87,
-            "translation": "생선 전골이 나오는 스트랩입니다.[LINE]\n생선이 메인인 전골. 생선 육수가[LINE]\n빠져나옵니다. 나머지는 죽으로 드세요.[END]"
+            "translation": "해물탕이 나오는 스트랩.[LINE]\n개운한 생선 육수는 참을 수 없다.[LINE]\n남은 건 죽을 끓이자.[END]"
         },
         {
             "offset": 1805072,
             "string": "[Sign_3]魚鍋[END]",
             "original_bytes_length": 10,
             "available_bytes_size": 15,
-            "translation": "[Sign_3]생선 전골[END]"
+            "translation": "[Sign_3]해물탕[END]"
         },
         {
             "offset": 1805088,
             "string": "みそ煮込み[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "된장 조림[END]"
+            "translation": "된장찌개[END]"
         },
         {
             "offset": 1805104,
             "string": "コラボ魚[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 생선[END]"
+            "translation": "콜라보 해물[END]"
         },
         {
             "offset": 1805120,
             "string": "魚[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "물고기[END]"
+            "translation": "해물[END]"
         },
         {
             "offset": 1805128,
             "string": "肉鍋が出るストラップ。[LINE]\nお肉がメインの鍋。肉の出汁が[LINE]\nたまりません。残りはうどんでも。[END]",
             "original_bytes_length": 85,
             "available_bytes_size": 87,
-            "translation": "고기 전골이 나오는 스트랩입니다.[LINE]\n고기가 메인인 전골. 고기 육수가[LINE]\n빠져나옵니다. 나머지는 우동으로도.[END]"
+            "translation": "고기 전골이 나오는 스트랩.[LINE]\n진한 고기 육수는 참을 수 없다.[LINE]\n남은 건 우동으로 만들자.[END]"
         },
         {
             "offset": 1805216,
@@ -467,28 +467,28 @@
             "string": "コラボパワ[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 파워[END]"
+            "translation": "콜라보 강력[END]"
         },
         {
             "offset": 1805264,
             "string": "パワ[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "파워[END]"
+            "translation": "강력[END]"
         },
         {
             "offset": 1805272,
             "string": "フルーツとうふが出るストラップ。[LINE]\nとうふとフルーツを混ぜた、[LINE]\nなんともいえない食感の食べ物。[END]",
             "original_bytes_length": 91,
             "available_bytes_size": 95,
-            "translation": "프루츠 두부가 나오는 스트랩입니다.[LINE]\n두부와 과일을 섞은, [LINE]\n말로 표현할 수 없는 식감의 음식이에요.[END]"
+            "translation": "과일 두부가 나오는 스트랩.[LINE]\n두부와 과일을 섞은,[LINE]\n형언할 수 없는 식감의 음식.[END]"
         },
         {
             "offset": 1805368,
             "string": "[Sign_3]フルーツとうふ[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23,
-            "translation": "[Sign_3]프루츠 두부[END]"
+            "translation": "[Sign_3]과일 두부[END]"
         },
         {
             "offset": 1805392,
@@ -502,126 +502,126 @@
             "string": "コラボビューチ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 뷰치[END]"
+            "translation": "콜라보 아름다운[END]"
         },
         {
             "offset": 1805424,
             "string": "ビューチ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "뷰치[END]"
+            "translation": "아름다운[END]"
         },
         {
             "offset": 1805440,
             "string": "フルーツチーズが出るストラップ。[LINE]\nすり潰したフルーツと牛乳を混ぜて[LINE]\nチーズにする。おやつにピッタリ！[END]",
             "original_bytes_length": 99,
             "available_bytes_size": 103,
-            "translation": "프루츠 치즈가 나오는 스트랩입니다.[LINE]\n갈아낸 과일과 우유를 섞어[LINE]\n치즈로 만듭니다. 간식으로 제격이에요![END]"
+            "translation": "과일 치즈가 나오는 스트랩.[LINE]\n잘게 썬 과일과 우유로 만든 치즈.[LINE]\n간식으로 딱 좋아![END]"
         },
         {
             "offset": 1805544,
             "string": "[Sign_3]フルーツチーズ[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23,
-            "translation": "[Sign_3]프루츠 치즈[END]"
+            "translation": "[Sign_3]과일 치즈[END]"
         },
         {
             "offset": 1805568,
             "string": "フルーツサラダ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "과일 샐러드[END]"
+            "translation": "과일 사라다[END]"
         },
         {
             "offset": 1805584,
             "string": "コラボワンダ[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 원더[END]"
+            "translation": "콜라보 환상적[END]"
         },
         {
             "offset": 1805600,
             "string": "ワンダ[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "원더[END]"
+            "translation": "환상적[END]"
         },
         {
             "offset": 1805608,
             "string": "フルーツパフェが出るストラップ。[LINE]\n色々なフルーツを生クリームや[LINE]\nアイスにトッピング。甘くてウマイ。[END]",
             "original_bytes_length": 97,
             "available_bytes_size": 103,
-            "translation": "프루츠 파르페가 나오는 스트랩입니다.[LINE]\n다양한 과일을 생크림이나[LINE]\n아이스크림에 토핑. 달콤하고 맛있습니다.[END]"
+            "translation": "생과일 파르페가 나오는 스트랩.[LINE]\n생크림이나 아이스크림 위에[LINE]\n여러 과일을 올렸다. 달고 맛있다.[END]"
         },
         {
             "offset": 1805712,
             "string": "[Sign_3]フルーツパフェ[END]",
             "original_bytes_length": 20,
             "available_bytes_size": 23,
-            "translation": "[Sign_3]프루츠 파르페[END]"
+            "translation": "[Sign_3]생과일 파르페[END]"
         },
         {
             "offset": 1805736,
             "string": "特上にぎり寿司[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "특상 주먹밥 초밥[END]"
+            "translation": "특상 초밥[END]"
         },
         {
             "offset": 1805752,
             "string": "コラボ大[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 대[END]"
+            "translation": "콜라보 대형[END]"
         },
         {
             "offset": 1805768,
             "string": "大[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "대[END]"
+            "translation": "대형[END]"
         },
         {
             "offset": 1805776,
             "string": "舟盛りが出るストラップ。[LINE]\n新鮮な魚介類を伝統にのっとって[LINE]\n盛りつけました。まだ生きてます。[END]",
             "original_bytes_length": 89,
             "available_bytes_size": 95,
-            "translation": "후나모리가 나오는 스트랩입니다.[LINE]\n신선한 해산물을 전통에 따라[LINE]\n담았습니다. 아직 살아있습니다.[END]"
+            "translation": "모둠회가 나오는 스트랩.[LINE]\n물고기를 배 모양 접시에 올렸다.[LINE]\n아직 살아있을 정도로 싱싱하다.[END]"
         },
         {
             "offset": 1805872,
             "string": "[Sign_3]舟盛り[END]",
             "original_bytes_length": 12,
             "available_bytes_size": 15,
-            "translation": "[Sign_3]후나모리[END]"
+            "translation": "[Sign_3]모둠회[END]"
         },
         {
             "offset": 1805888,
             "string": "トロのあぶり握り[END]",
             "original_bytes_length": 17,
             "available_bytes_size": 23,
-            "translation": "참치 초밥[END]"
+            "translation": "구운 참치 초밥[END]"
         },
         {
             "offset": 1805912,
             "string": "コラボお[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 오[END]"
+            "translation": "콜라보 큰[END]"
         },
         {
             "offset": 1805928,
             "string": "お[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "오[END]"
+            "translation": "큰[END]"
         },
         {
             "offset": 1805936,
             "string": "お刺身が出るストラップ。[LINE]\n新鮮な魚介類を薄く切ったもの。[LINE]\nプリプリとした身がたまらない。[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87,
-            "translation": "생선회가 나오는 스트랩입니다.[LINE]\n신선한 어패류를 얇게 썬 것입니다.[LINE]\n탱탱한 식감이 일품입니다.[END]"
+            "translation": "생선회가 나오는 스트랩.[LINE]\n신선한 물고기를 얇게 썬 요리.[LINE]\n탱탱한 식감이 일품.[END]"
         },
         {
             "offset": 1806024,
@@ -642,21 +642,21 @@
             "string": "コラボ結構[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 꽤[END]"
+            "translation": "콜라보 훌륭한[END]"
         },
         {
             "offset": 1806072,
             "string": "結構[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "꽤[END]"
+            "translation": "훌륭한[END]"
         },
         {
             "offset": 1806080,
             "string": "すき焼きが出るストラップ。[LINE]\n牛肉を鉄鍋で甘辛く焼いて煮たもの。[LINE]\nお米と一緒に食べても合います。[END]",
             "original_bytes_length": 93,
             "available_bytes_size": 95,
-            "translation": "스키야키가 나오는 스트랩입니다.[LINE]\n소고기를 철냄비에서 달콤하게 구워서 끓인 것.[LINE]\n밥과 함께 먹어도 잘 어울립니다.[END]"
+            "translation": "스키야키가 나오는 스트랩.[LINE]\n잘 끓인 불고기를 날계란에 푹.[LINE]\n밥하고 먹어도 잘 어울린다.[END]"
         },
         {
             "offset": 1806176,
@@ -670,28 +670,28 @@
             "string": "たこ焼き[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "타코야끼[END]"
+            "translation": "타코야키[END]"
         },
         {
             "offset": 1806208,
             "string": "コラボかなり[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 꽤[END]"
+            "translation": "콜라보 꽤 하는[END]"
         },
         {
             "offset": 1806224,
             "string": "かなり[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "꽤[END]"
+            "translation": "꽤 하는[END]"
         },
         {
             "offset": 1806232,
             "string": "お好み焼きが出るストラップ。[LINE]\n水で溶いた小麦粉にお好みの具を。[LINE]\nトッピングにかつお節と青ノリを。[END]",
             "original_bytes_length": 95,
             "available_bytes_size": 95,
-            "translation": "오코노미야키가 나오는 스트랩입니다.[LINE]\n물에 풀어 만든 밀가루 반죽에 원하는 재료를.[LINE]\n토핑으로 가다랑어포와 김가루를.[END]"
+            "translation": "오코노미야키가 나오는 스트랩.[LINE]\n묽은 밀가루 반죽에 재료는 취향대로.[LINE]\n토핑은 가다랑어포와 김가루.[END]"
         },
         {
             "offset": 1806328,
@@ -705,7 +705,7 @@
             "string": "サイコロステーキ[END]",
             "original_bytes_length": 17,
             "available_bytes_size": 23,
-            "translation": "사이코로 스테이크[END]"
+            "translation": "큐브 스테이크[END]"
         },
         {
             "offset": 1806368,
@@ -726,7 +726,7 @@
             "string": "ステーキが出るストラップ。[LINE]\n厚く切った肉をただ焼くだけ！[LINE]\n肉の素晴らしさが実感できます。[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87,
-            "translation": "스테이크가 나오는 스트랩입니다.[LINE]\n두껍게 썬 고기를 그냥 구우면 됩니다![LINE]\n고기의 훌륭함을 실감할 수 있습니다.[END]"
+            "translation": "스테이크가 나오는 스트랩.[LINE]\n두툼한 고기를 굽기만 하면 된다고![LINE]\n고기의 훌륭함을 실감할 수 있다.[END]"
         },
         {
             "offset": 1806488,
@@ -740,35 +740,35 @@
             "string": "チーズハンバーグ[END]",
             "original_bytes_length": 17,
             "available_bytes_size": 23,
-            "translation": "치즈 함바그[END]"
+            "translation": "치즈 햄버그[END]"
         },
         {
             "offset": 1806528,
             "string": "コラボ半端ない[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 반전[END]"
+            "translation": "콜라보 장난 아닌[END]"
         },
         {
             "offset": 1806544,
             "string": "半端ない[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "반전[END]"
+            "translation": "장난 아닌[END]"
         },
         {
             "offset": 1806560,
             "string": "ハンバーグが出るストラップ。[LINE]\nつけ合わせは甘く煮たにんじんを。[LINE]\nよく捏ねるほど美味しくなります。[END]",
             "original_bytes_length": 95,
             "available_bytes_size": 95,
-            "translation": "햄버거가 나오는 스트랩입니다.[LINE]\n달콤하게 조린 당근을 곁들여 먹습니다.[LINE]\n잘 반죽할수록 맛있어집니다.[END]"
+            "translation": "햄버그가 나오는 스트랩.[LINE]\n달달한 당근을 곁들여 먹는다.[LINE]\n잘 반죽할수록 맛있어진다.[END]"
         },
         {
             "offset": 1806656,
             "string": "[Sign_3]ハンバーグ[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16,
-            "translation": "[Sign_3]햄버거[END]"
+            "translation": "[Sign_3]햄버그[END]"
         },
         {
             "offset": 1806672,
@@ -796,14 +796,14 @@
             "string": "グラスパが出るストラップ。[LINE]\nグラタンとスパゲッティを同時に[LINE]\n楽しめる逸品！まずは一口。[END]",
             "original_bytes_length": 85,
             "available_bytes_size": 87,
-            "translation": "그라탱과 스파게티를 동시에 즐길 수 있는[LINE]\n식품입니다! 우선 한 입.[END]"
+            "translation": "그라탱 스파게티가 나오는 스트랩.[LINE]\n그라탕과 스파게티를 같이 즐기자![LINE]\n우선 한 입 냠냠.[END]"
         },
         {
             "offset": 1806800,
             "string": "[Sign_3]グラスパ[END]",
             "original_bytes_length": 14,
             "available_bytes_size": 15,
-            "translation": "[Sign_3]그라스파[END]"
+            "translation": "[Sign_3]그라탱 스파게티[END]"
         },
         {
             "offset": 1806816,
@@ -831,7 +831,7 @@
             "string": "グラタンが出るストラップ。[LINE]\nたっぷり具材にたっぷりチーズ。焦[LINE]\nげたチーズの香りは空腹を誘います。[END]",
             "original_bytes_length": 95,
             "available_bytes_size": 95,
-            "translation": "그라탱이 나오는 스트랩입니다.[LINE]\n풍성한 속재료에 치즈가 가득.[LINE]\n구운 치즈의 향기는 공복을 자아낸다.[END]"
+            "translation": "그라탱이 나오는 스트랩.[LINE]\n풍성한 속재료에 치즈가 가득.[LINE]\n노릇노릇한 치즈 향이 식욕을 돋운다.[END]"
         },
         {
             "offset": 1806952,
@@ -866,7 +866,7 @@
             "string": "ミートソースが出るストラップ。[LINE]\nタマネギとひき肉はたっぷりと。[LINE]\nソースの跳ねに要注意。[END]",
             "original_bytes_length": 85,
             "available_bytes_size": 87,
-            "translation": "미트 소스가 나오는 스트랩입니다.[LINE]\n양파와 다진 고기가 풍성하게.[LINE]\n소스 튐에 주의하세요.[END]"
+            "translation": "미트 소스가 나오는 스트랩.[LINE]\n양파와 다진 고기가 듬뿍.[LINE]\n소스가 잘 튀니 조심하자.[END]"
         },
         {
             "offset": 1807104,
@@ -880,28 +880,28 @@
             "string": "豚の角煮[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "돼지고기 간장조림[END]"
+            "translation": "돼지고기 장조림[END]"
         },
         {
             "offset": 1807144,
             "string": "コラボとろとろ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 부드럽게[END]"
+            "translation": "콜라보 뭉근한[END]"
         },
         {
             "offset": 1807160,
             "string": "とろとろ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "부드럽게[END]"
+            "translation": "뭉근한[END]"
         },
         {
             "offset": 1807176,
             "string": "ビーフストロガノフが出るストラップ。[LINE]\n牛肉をサワークリームのソースで煮[LINE]\n込んだもの。贅沢で上品なお味。[END]",
             "original_bytes_length": 101,
             "available_bytes_size": 103,
-            "translation": "비프 스트로가노프가 나오는 스트랩입니다.[LINE]\n소고기를 사워크림 소스에 끓인 것.[LINE]\n사치스럽고 고급스러운 맛입니다.[END]"
+            "translation": "비프 스트로가노프가 나오는 스트랩.[LINE]\n소고기를 사워크림 소스에 끓인 요리.[LINE]\n사치스럽고 고급스러운 맛.[END]"
         },
         {
             "offset": 1807280,
@@ -936,14 +936,14 @@
             "string": "リゾットが出るストラップ。[LINE]\n油で炒めた米に肉や魚、キノコで炒[LINE]\nめたスープを含ませたもの。[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87,
-            "translation": "리조또가 나오는 스트랩입니다.[LINE]\n기름에 볶은 쌀에 고기나 생선, 버섯으로 볶은[LINE]\n수프를 포함시킨 것입니다.[END]"
+            "translation": "리소토가 나오는 스트랩.[LINE]\n볶은 쌀에 고기나 생선, 버섯 육수를[LINE]\n같이 부어서 졸였다.[END]"
         },
         {
             "offset": 1807440,
             "string": "[Sign_3]リゾット[END]",
             "original_bytes_length": 14,
             "available_bytes_size": 15,
-            "translation": "[Sign_3]리조또[END]"
+            "translation": "[Sign_3]리소토[END]"
         },
         {
             "offset": 1807456,
@@ -971,7 +971,7 @@
             "string": "クラムチャウダーが出るストラップ。[LINE]\nハマグリとベーコン・野菜などを[LINE]\n煮込んだスープ。寒い日にどうぞ。[END]",
             "original_bytes_length": 99,
             "available_bytes_size": 103,
-            "translation": "클램 차우더가 나오는 스트랩입니다.[LINE]\n대합과 베이컨, 야채 등을[LINE]\n끓인 스프. 추운 날에 드세요.[END]"
+            "translation": "클램 차우더가 나오는 스트랩.[LINE]\n대합과 베이컨, 채소를 넣은 스프.[LINE]\n추운 날에 먹자.[END]"
         },
         {
             "offset": 1807608,
@@ -985,28 +985,28 @@
             "string": "うに丼[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "성게덮밥[END]"
+            "translation": "성게알 덮밥[END]"
         },
         {
             "offset": 1807640,
             "string": "コラボとびきり[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 특별히[END]"
+            "translation": "콜라보 특별한[END]"
         },
         {
             "offset": 1807656,
             "string": "とびきり[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "특별히[END]"
+            "translation": "특별한[END]"
         },
         {
             "offset": 1807672,
             "string": "海鮮丼が出るストラップ。[LINE]\n新鮮な魚介類をご飯の上へ。季節に[LINE]\nよって素材も変わる。贅沢な一品。[END]",
             "original_bytes_length": 91,
             "available_bytes_size": 95,
-            "translation": "해산물 덮밥이 나오는 스트랩입니다.[LINE]\n신선한 해산물을 밥 위에 올립니다. 계절에[LINE]\n따라 재료도 변합니다. 사치스러운 음식.[END]"
+            "translation": "해산물 덮밥이 나오는 스트랩.[LINE]\n신선한 해산물을 밥 위에 얹어 먹는다.[LINE]\n계절마다 재료가 바뀌는 호화로운 음식.[END]"
         },
         {
             "offset": 1807768,
@@ -1041,14 +1041,14 @@
             "string": "親子丼が出るストラップ。[LINE]\n甘く煮た鶏肉を卵でとじました。[LINE]\n白飯と一緒にお食べください。[END]",
             "original_bytes_length": 85,
             "available_bytes_size": 87,
-            "translation": "닭고기 계란덮밥이 나오는 스트랩입니다.[LINE]\n달콤하게 조리한 닭고기를 계란으로 덮었습니다.[LINE]\n흰밥과 함께 드세요.[END]"
+            "translation": "닭고기 달걀덮밥이 나오는 스트랩.[LINE]\n달달한 닭고기에 달걀물을 부었다.[LINE]\n흰 쌀밥과 같이 먹자.[END]"
         },
         {
             "offset": 1807912,
             "string": "[Sign_3]親子丼[END]",
             "original_bytes_length": 12,
             "available_bytes_size": 15,
-            "translation": "[Sign_3]닭고기 계란덮밥[END]"
+            "translation": "[Sign_3]닭고기 달걀덮밥[END]"
         },
         {
             "offset": 1807928,
@@ -1076,7 +1076,7 @@
             "string": "牛丼が出るストラップ。[LINE]\n牛肉をネギなどと煮て、汁とともに[LINE]\nどんぶり飯に。忘れられない味。[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87,
-            "translation": "쇠고기 덮밥이 나오는 스트랩입니다.[LINE]\n소고기를 파 등과 함께 끓여, 국물과 함께[LINE]\n덮밥에. 잊을 수 없는 맛입니다.[END]"
+            "translation": "쇠고기 덮밥이 나오는 스트랩.[LINE]\n불고기처럼 끓인 소고기를 덮밥으로.[LINE]\n잊을 수 없는 맛.[END]"
         },
         {
             "offset": 1808056,
@@ -1090,7 +1090,7 @@
             "string": "ライスバーガー[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "라이스버거[END]"
+            "translation": "밥버거[END]"
         },
         {
             "offset": 1808088,
@@ -1111,7 +1111,7 @@
             "string": "ロコモコが出るストラップ。[LINE]\nご飯の上にハンバーグと目玉焼き。[LINE]\nシンプルだけどめちゃうまい！[END]",
             "original_bytes_length": 89,
             "available_bytes_size": 95,
-            "translation": "로코모코가 나오는 스트랩입니다.[LINE]\n밥 위에 햄버거와 계란 후라이.[LINE]\n단순하지만 정말 맛있어요![END]"
+            "translation": "로코모코가 나오는 스트랩.[LINE]\n햄버그와 달걀프라이를[LINE]\n밥 위에 얹었다. 단순하지만 맛있다![END]"
         },
         {
             "offset": 1808208,
@@ -1125,35 +1125,35 @@
             "string": "カレーまん[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "카레 만주[END]"
+            "translation": "카레호빵[END]"
         },
         {
             "offset": 1808240,
             "string": "コラボ回鍋[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 회귀[END]"
+            "translation": "콜라보 두 번 찐[END]"
         },
         {
             "offset": 1808256,
             "string": "回鍋[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "회귀[END]"
+            "translation": "두 번 찐[END]"
         },
         {
             "offset": 1808264,
             "string": "肉まんが出るストラップ。[LINE]\n一口食べれば口いっぱいに肉汁が！[LINE]\n寒い日は食べたくなる一品。[END]",
             "original_bytes_length": 85,
             "available_bytes_size": 87,
-            "translation": "고기만두가 나오는 스트랩.[LINE]\n한 입 먹으면 입 가득 육즙이! [LINE]\n추운 날엔 먹고 싶은 한 접시다.[END]"
+            "translation": "고기호빵이 나오는 스트랩.[LINE]\n한 입 먹으면 입안 가득 육즙이! [LINE]\n추운 날에 먹고 싶어지는 맛.[END]"
         },
         {
             "offset": 1808352,
             "string": "[Sign_3]肉まん[END]",
             "original_bytes_length": 12,
             "available_bytes_size": 15,
-            "translation": "[Sign_3]고기만두[END]"
+            "translation": "[Sign_3]고기호빵[END]"
         },
         {
             "offset": 1808368,
@@ -1167,21 +1167,21 @@
             "string": "コラボ激辛[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 매운맛[END]"
+            "translation": "콜라보 아주 매운[END]"
         },
         {
             "offset": 1808408,
             "string": "激辛[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "매운맛[END]"
+            "translation": "아주 매운[END]"
         },
         {
             "offset": 1808416,
             "string": "キムチが出るストラップ。[LINE]\n辛いものが苦手な人は要注意。[LINE]\n匂いも味も刺激的。[END]",
             "original_bytes_length": 73,
             "available_bytes_size": 79,
-            "translation": "김치가 나오는 스트랩입니다.[LINE]\n매운 음식을 못 먹는 사람은 주의하세요.[LINE]\n향도 맛도 자극적입니다.[END]"
+            "translation": "김치가 나오는 스트랩.[LINE]\n매운맛에 약한 사람은 주의할 것.[LINE]\n향도 맛도 자극적.[END]"
         },
         {
             "offset": 1808496,
@@ -1195,7 +1195,7 @@
             "string": "蒸しぱん[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "찐빵[END]"
+            "translation": "술빵[END]"
         },
         {
             "offset": 1808528,
@@ -1216,7 +1216,7 @@
             "string": "マフィンが出るストラップ。[LINE]\nふくらませた小さな丸い菓子パン。[LINE]\n生クリームをつけるのもお勧め。[END]",
             "original_bytes_length": 91,
             "available_bytes_size": 95,
-            "translation": "머핀 나오는 스트랩입니다.[LINE]\n부풀린 작은 둥근 과자빵입니다.[LINE]\n생크림을 곁들이는 것도 추천합니다.[END]"
+            "translation": "머핀이 나오는 스트랩.[LINE]\n봉긋하게 부푼 작고 둥근 빵.[LINE]\n생크림을 얹어도 맛있다.[END]"
         },
         {
             "offset": 1808648,
@@ -1237,21 +1237,21 @@
             "string": "コラボ武勇[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 무용[END]"
+            "translation": "콜라보 무쌍[END]"
         },
         {
             "offset": 1808704,
             "string": "武勇[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "무용[END]"
+            "translation": "무쌍[END]"
         },
         {
             "offset": 1808712,
             "string": "オリエンタルライスが出るストラップ。[LINE]\nにらと豚バラ肉をご飯にのせ[LINE]\nたもの。スタミナ抜群！[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87,
-            "translation": "오리엔탈 라이스가 나오는 스트랩입니다.[LINE]\n부추와 돼지고기 안심살을 밥 위에 올린 것.[LINE]\n스태미나가 뛰어납니다![END]"
+            "translation": "오리엔탈 라이스가 나오는 스트랩.[LINE]\n부추와 삼겹살을 밥에 얹었다.[LINE]\n원기 회복에 좋다![END]"
         },
         {
             "offset": 1808800,
@@ -1265,35 +1265,35 @@
             "string": "煮込みラーメン[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "조림 라면[END]"
+            "translation": "푹 끓인 라멘[END]"
         },
         {
             "offset": 1808840,
             "string": "コラボ山の幸[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 산의 행복[END]"
+            "translation": "콜라보 육지산[END]"
         },
         {
             "offset": 1808856,
             "string": "山の幸[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "산의 행복[END]"
+            "translation": "육지산[END]"
         },
         {
             "offset": 1808864,
             "string": "パエリアが出るストラップ。[LINE]\n米に肉や魚介類を入れ、オリーブ油[LINE]\nとサフランを加えて煮込んだもの。[END]",
             "original_bytes_length": 93,
             "available_bytes_size": 95,
-            "translation": "파엘리아가 나오는 스트랩입니다.[LINE]\n쌀에 고기와 해산물을 넣고 올리브 오일[LINE]\n과 사프란을 넣어 끓인 것입니다.[END]"
+            "translation": "파에야가 나오는 스트랩.[LINE]\n쌀에 고기나 해산물을 넣고[LINE]\n올리브유와 사프란 육수로 끓인 것.[END]"
         },
         {
             "offset": 1808960,
             "string": "[Sign_3]パエリア[END]",
             "original_bytes_length": 14,
             "available_bytes_size": 15,
-            "translation": "[Sign_3]파엘리아[END]"
+            "translation": "[Sign_3]파에야[END]"
         },
         {
             "offset": 1808976,
@@ -1307,28 +1307,28 @@
             "string": "コラボ思わず[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 놀라움[END]"
+            "translation": "콜라보 어머나[END]"
         },
         {
             "offset": 1809008,
             "string": "思わず[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "놀라움[END]"
+            "translation": "어머나[END]"
         },
         {
             "offset": 1809016,
             "string": "オムハヤシが出るストラップ。[LINE]\nオムライスとハヤシライスの合体！[LINE]\nボリュームタップリで贅沢な味です。[END]",
             "original_bytes_length": 97,
             "available_bytes_size": 103,
-            "translation": "오므라이스와 하야시 라이스의 합체입니다![LINE]\n볼륨이 가득하고 풍성한 맛입니다.[END]"
+            "translation": "오므하이라이스가 나오는 스트랩.[LINE]\n오므라이스와 하이라이스의 합체![LINE]\n볼륨 가득한 사치스러운 맛.[END]"
         },
         {
             "offset": 1809120,
             "string": "[Sign_3]オムハヤシ[END]",
             "original_bytes_length": 16,
             "available_bytes_size": 16,
-            "translation": "[Sign_3]오므하야시[END]"
+            "translation": "[Sign_3]오므하이라이스[END]"
         },
         {
             "offset": 1809136,
@@ -1342,28 +1342,28 @@
             "string": "コラボ辛口[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 매운맛[END]"
+            "translation": "콜라보 매운 맛[END]"
         },
         {
             "offset": 1809168,
             "string": "辛口[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "매운맛[END]"
+            "translation": "매운 맛[END]"
         },
         {
             "offset": 1809176,
             "string": "カレーライスが出るストラップ。[LINE]\nリンゴとハチミツ入り。甘くて少し[LINE]\nスパイシー。家庭の味です。[END]",
             "original_bytes_length": 91,
             "available_bytes_size": 95,
-            "translation": "커리라이스가 나오는 스트랩.[LINE]\n사과와 꿀이 들어있다. 달콤하고 약간[LINE]\n매콤하다. 집밥의 맛이다.[END]"
+            "translation": "카레라이스가 나오는 스트랩.[LINE]\n사과와 꿀이 들어가서 달콤하고[LINE]\n약간 맵다. 집밥의 맛.[END]"
         },
         {
             "offset": 1809272,
             "string": "[Sign_3]カレーライス[END]",
             "original_bytes_length": 18,
             "available_bytes_size": 23,
-            "translation": "[Sign_3]커리라이스[END]"
+            "translation": "[Sign_3]카레라이스[END]"
         },
         {
             "offset": 1809296,
@@ -1391,7 +1391,7 @@
             "string": "オムライスが出るストラップ。[LINE]\nケチャップご飯にトロトロ卵を被せ[LINE]\nたもの。子供たちの大好物。[END]",
             "original_bytes_length": 89,
             "available_bytes_size": 95,
-            "translation": "오므라이스가 나오는 스트랩입니다.[LINE]\n케첩 밥 위에 부드러운 계란을 얹은 것.[LINE]\n아이들이 좋아하는 음식입니다.[END]"
+            "translation": "오므라이스가 나오는 스트랩.[LINE]\n케첩과 밥 위에 달걀 지단을 얹은 것.[LINE]\n아이들이 매우 좋아한다.[END]"
         },
         {
             "offset": 1809440,
@@ -1412,21 +1412,21 @@
             "string": "コラボパラパラ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 파라파라[END]"
+            "translation": "콜라보 고슬고슬[END]"
         },
         {
             "offset": 1809488,
             "string": "パラパラ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "파라파라[END]"
+            "translation": "고슬고슬[END]"
         },
         {
             "offset": 1809504,
             "string": "チャーハンが出るストラップ。[LINE]\n肉や野菜・卵などをまぜて油で炒め[LINE]\n味をつけた焼き飯。単品でも満足。[END]",
             "original_bytes_length": 95,
             "available_bytes_size": 95,
-            "translation": "볶음밥이 나오는 스트랩입니다.[LINE]\n고기와 채소, 계란 등을 섞어 기름에 볶아[LINE]\n맛을 낸 볶음밥입니다. 단품으로도 만족합니다.[END]"
+            "translation": "볶음밥이 나오는 스트랩.[LINE]\n고기, 채소, 달걀 등을 기름에 볶았다.[LINE]\n이것만 먹어도 맛있다.[END]"
         },
         {
             "offset": 1809600,
@@ -1440,28 +1440,28 @@
             "string": "さけ茶漬け[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "연어 차즈케[END]"
+            "translation": "연어 오차즈케[END]"
         },
         {
             "offset": 1809632,
             "string": "コラボかつ[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 돈까스[END]"
+            "translation": "콜라보 가다랑어[END]"
         },
         {
             "offset": 1809648,
             "string": "かつ[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "돈까스[END]"
+            "translation": "가다랑어[END]"
         },
         {
             "offset": 1809656,
             "string": "お茶漬けが出るストラップ。[LINE]\nご飯に薄味のだし汁をかけて食べる[LINE]\nもの。さらさらっとかっ込めます。[END]",
             "original_bytes_length": 93,
             "available_bytes_size": 95,
-            "translation": "오차즈케가 나오는 스트랩.[LINE]\n밥에 담백한 국물을 부어 먹는 것.[LINE]\n쓱쓱 비벼 먹을 수 있다.[END]"
+            "translation": "오차즈케가 나오는 스트랩.[LINE]\n밥에 담백한 차를 부어서 먹는다.[LINE]\n쓱쓱 비비면 술술 넘어간다.[END]"
         },
         {
             "offset": 1809752,
@@ -1482,56 +1482,56 @@
             "string": "コラボ千夜[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 천야[END]"
+            "translation": "콜라보 천일 묵은[END]"
         },
         {
             "offset": 1809800,
             "string": "千夜[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "천야[END]"
+            "translation": "천일 묵은[END]"
         },
         {
             "offset": 1809808,
             "string": "一夜漬けが出るストラップ。[LINE]\n一夜で漬けた漬物。[LINE]\nあっさりして食べやすい。[END]",
             "original_bytes_length": 71,
             "available_bytes_size": 71,
-            "translation": "이치야즈케가 나오는 스트랩.[LINE]\n하룻밤 동안 절인 채소절임.[LINE]\n담백해서 먹기 쉽다.[END]"
+            "translation": "겉절이가 나오는 스트랩.[LINE]\n채소를 하룻밤 동안 절인 요리.[LINE]\n담백해서 먹기 쉽다.[END]"
         },
         {
             "offset": 1809880,
             "string": "[Sign_3]一夜漬け[END]",
             "original_bytes_length": 14,
             "available_bytes_size": 15,
-            "translation": "[Sign_3]이치야즈케[END]"
+            "translation": "[Sign_3]겉절이[END]"
         },
         {
             "offset": 1809896,
             "string": "きつねうどん[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "여우 우동[END]"
+            "translation": "유부우동[END]"
         },
         {
             "offset": 1809912,
             "string": "コラボすご[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 엄청[END]"
+            "translation": "콜라보 엄청난[END]"
         },
         {
             "offset": 1809928,
             "string": "すご[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "엄청[END]"
+            "translation": "엄청난[END]"
         },
         {
             "offset": 1809936,
             "string": "いなり寿司が出るストラップ。[LINE]\n甘く煮た油揚げの中にすし飯を詰め[LINE]\nたもの。お子様にも人気。[END]",
             "original_bytes_length": 87,
             "available_bytes_size": 87,
-            "translation": "유부초밥이 나오는 스트랩입니다.[LINE]\n달콤하게 조리한 유부 안에 초밥을 채운 것.[LINE]\n어린이들에게도 인기입니다.[END]"
+            "translation": "유부초밥이 나오는 스트랩.[LINE]\n달달한 유부 안에 초밥을 채웠다.[LINE]\n어린이에게도 인기.[END]"
         },
         {
             "offset": 1810024,
@@ -1566,7 +1566,7 @@
             "string": "ケバブが出るストラップ。[LINE]\n串に刺した肉をゆっくりと回しなが[LINE]\nらじっくり焼き上げたもの。[END]",
             "original_bytes_length": 85,
             "available_bytes_size": 87,
-            "translation": "케밥이 나오는 스트랩.[LINE]\n꼬치에 꽂은 고기를 천천히 돌리면서[LINE]\n잘 구워낸 것이다.[END]"
+            "translation": "케밥이 나오는 스트랩.[LINE]\n꼬챙이에 꽂은 고기를[LINE]\n천천히 돌리면서 구웠다.[END]"
         },
         {
             "offset": 1810168,
@@ -1601,14 +1601,14 @@
             "string": "ブリトーが出るストラップ。[LINE]\nライス・肉・豆・野菜などの具を[LINE]\nトルティーヤで巻いたもの。[END]",
             "original_bytes_length": 85,
             "available_bytes_size": 87,
-            "translation": "브리또가 나오는 스트랩.[LINE]\n밥, 고기, 콩, 야채 등의 재료를[LINE]\n또르티야로 감싼 것이다.[END]"
+            "translation": "부리토가 나오는 스트랩.[LINE]\n밥, 고기, 콩, 채소 등의 재료를[LINE]\n토르티야로 감싼 요리.[END]"
         },
         {
             "offset": 1810312,
             "string": "[Sign_3]ブリトー[END]",
             "original_bytes_length": 14,
             "available_bytes_size": 15,
-            "translation": "[Sign_3]브리또[END]"
+            "translation": "[Sign_3]부리토[END]"
         },
         {
             "offset": 1810328,
@@ -1636,7 +1636,7 @@
             "string": "ホットドッグが出るストラップ。[LINE]\n細長いパンに切れ目を入れ、温めた[LINE]\nソーセージをはさんだもの。[END]",
             "original_bytes_length": 91,
             "available_bytes_size": 95,
-            "translation": "핫도그가 나오는 스트랩입니다.[LINE]\n가늘고 긴 빵에 칼집을 내서, 따뜻한[LINE]\n소시지를 넣은 것입니다.[END]"
+            "translation": "핫도그가 나오는 스트랩.[LINE]\n길쭉한 빵에 칼집을 내서,[LINE]\n따뜻한 소시지를 넣었다.[END]"
         },
         {
             "offset": 1810464,
@@ -1671,7 +1671,7 @@
             "string": "ハンバーガーが出るストラップ。[LINE]\nジューシーなハンバーグをパンで[LINE]\n挟みました。ボリューム満点！[END]",
             "original_bytes_length": 91,
             "available_bytes_size": 95,
-            "translation": "햄버거가 나오는 스트랩입니다.[LINE]\n육즙이 풍부한 햄버거를 빵으로[LINE]\n겹쳤습니다. 볼륨 만점입니다![END]"
+            "translation": "햄버거가 나오는 스트랩.[LINE]\n육즙이 풍부한 패티를[LINE]\n빵 사이에 끼웠다. 볼륨 만점![END]"
         },
         {
             "offset": 1810632,
@@ -1685,7 +1685,7 @@
             "string": "ハムエッグサンド[END]",
             "original_bytes_length": 17,
             "available_bytes_size": 23,
-            "translation": "햄 에그 샌드[END]"
+            "translation": "햄 에그 샌드위치[END]"
         },
         {
             "offset": 1810680,
@@ -1706,7 +1706,7 @@
             "string": "サンドイッチが出るストラップ。[LINE]\n野菜とハムをサンドしたもの。[LINE]\nどこでも手軽に食べられます。[END]",
             "original_bytes_length": 89,
             "available_bytes_size": 95,
-            "translation": "샌드위치가 나오는 스트랩입니다.[LINE]\n채소와 햄을 겹친 것입니다.[LINE]\n어디서나 간편하게 먹을 수 있습니다.[END]"
+            "translation": "샌드위치가 나오는 스트랩.[LINE]\n채소와 햄을 채워 넣은 요리.[LINE]\n어디서나 간편하게 먹을 수 있다.[END]"
         },
         {
             "offset": 1810816,
@@ -1720,28 +1720,28 @@
             "string": "手巻き寿司[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "손말이 스시[END]"
+            "translation": "손말이 초밥[END]"
         },
         {
             "offset": 1810856,
             "string": "コラボのりパリ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 김 바삭[END]"
+            "translation": "콜라보 바삭김[END]"
         },
         {
             "offset": 1810872,
             "string": "のりパリ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "김 바삭[END]"
+            "translation": "바삭김[END]"
         },
         {
             "offset": 1810888,
             "string": "おにぎりが出るストラップ。[LINE]\n愛情を込めて丁寧に握りました。[LINE]\n旅のお供に最適。[END]",
             "original_bytes_length": 75,
             "available_bytes_size": 79,
-            "translation": "주먹밥이 나오는 스트랩입니다.[LINE]\n사랑을 담아 정성껏 만들었습니다.[LINE]\n여행을 떠날 때 최고.[END]"
+            "translation": "주먹밥이 나오는 스트랩.[LINE]\n사랑을 담아 정성껏 만들었다.[LINE]\n여행길 최고의 동반자.[END]"
         },
         {
             "offset": 1810968,

--- a/translations/binaries/slps_strings_items_food.json
+++ b/translations/binaries/slps_strings_items_food.json
@@ -12,14 +12,14 @@
             "string": "コラボ深[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 심각한[END]"
+            "translation": "콜라보 심각한 [END]"
         },
         {
             "offset": 1803304,
             "string": "深[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "심각한[END]"
+            "translation": "심각한 [END]"
         },
         {
             "offset": 1803312,
@@ -47,14 +47,14 @@
             "string": "コラボ光と[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 빛과[END]"
+            "translation": "콜라보 빛과 [END]"
         },
         {
             "offset": 1803440,
             "string": "光と[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "빛과[END]"
+            "translation": "빛과 [END]"
         },
         {
             "offset": 1803448,
@@ -82,14 +82,14 @@
             "string": "コラボ四[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 완전[END]"
+            "translation": "콜라보 완전 [END]"
         },
         {
             "offset": 1803592,
             "string": "四[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "완전[END]"
+            "translation": "완전 [END]"
         },
         {
             "offset": 1803600,
@@ -117,14 +117,14 @@
             "string": "コラボ懐か[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 퍼진[END]"
+            "translation": "콜라보 그립고 [END]"
         },
         {
             "offset": 1803736,
             "string": "懐か[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "퍼진[END]"
+            "translation": "그립고 [END]"
         },
         {
             "offset": 1803744,
@@ -222,14 +222,14 @@
             "string": "コラボパサ[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 퍼석퍼석[END]"
+            "translation": "콜라보 퍼석퍼석 [END]"
         },
         {
             "offset": 1804208,
             "string": "パサ[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "퍼석퍼석[END]"
+            "translation": "퍼석퍼석 [END]"
         },
         {
             "offset": 1804216,
@@ -257,14 +257,14 @@
             "string": "コラボ目がチ[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "따끔따끔[END]"
+            "translation": "콜라보 따끔따끔 [END]"
         },
         {
             "offset": 1804368,
             "string": "目がチ[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "따끔따끔[END]"
+            "translation": "따끔따끔 [END]"
         },
         {
             "offset": 1804376,
@@ -327,14 +327,14 @@
             "string": "コラボあわせ[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 모둠[END]"
+            "translation": "콜라보 모둠 [END]"
         },
         {
             "offset": 1804672,
             "string": "あわせ[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "모둠[END]"
+            "translation": "모둠 [END]"
         },
         {
             "offset": 1804680,
@@ -362,14 +362,14 @@
             "string": "コラボ親[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 대박[END]"
+            "translation": "콜라보 대박 [END]"
         },
         {
             "offset": 1804840,
             "string": "親[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "대박[END]"
+            "translation": "대박 [END]"
         },
         {
             "offset": 1804848,
@@ -397,14 +397,14 @@
             "string": "コラボ深海[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 심해[END]"
+            "translation": "콜라보 심해 [END]"
         },
         {
             "offset": 1804976,
             "string": "深海[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "심해[END]"
+            "translation": "심해 [END]"
         },
         {
             "offset": 1804984,
@@ -432,14 +432,14 @@
             "string": "コラボ魚[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 해물[END]"
+            "translation": "콜라보 해물 [END]"
         },
         {
             "offset": 1805120,
             "string": "魚[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "해물[END]"
+            "translation": "해물 [END]"
         },
         {
             "offset": 1805128,
@@ -467,14 +467,14 @@
             "string": "コラボパワ[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 강력[END]"
+            "translation": "콜라보 단단한 [END]"
         },
         {
             "offset": 1805264,
             "string": "パワ[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "강력[END]"
+            "translation": "단단한 [END]"
         },
         {
             "offset": 1805272,
@@ -502,14 +502,14 @@
             "string": "コラボビューチ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 아름다운[END]"
+            "translation": "콜라보 아름다운 [END]"
         },
         {
             "offset": 1805424,
             "string": "ビューチ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "아름다운[END]"
+            "translation": "아름다운 [END]"
         },
         {
             "offset": 1805440,
@@ -530,21 +530,21 @@
             "string": "フルーツサラダ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "과일 사라다[END]"
+            "translation": "과일 샐러드[END]"
         },
         {
             "offset": 1805584,
             "string": "コラボワンダ[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 환상적[END]"
+            "translation": "콜라보 환상적 [END]"
         },
         {
             "offset": 1805600,
             "string": "ワンダ[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "환상적[END]"
+            "translation": "환상적 [END]"
         },
         {
             "offset": 1805608,
@@ -572,14 +572,14 @@
             "string": "コラボ大[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 대형[END]"
+            "translation": "콜라보 대형 [END]"
         },
         {
             "offset": 1805768,
             "string": "大[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "대형[END]"
+            "translation": "대형 [END]"
         },
         {
             "offset": 1805776,
@@ -607,14 +607,14 @@
             "string": "コラボお[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "콜라보 큰[END]"
+            "translation": "콜라보 큰 [END]"
         },
         {
             "offset": 1805928,
             "string": "お[END]",
             "original_bytes_length": 3,
             "available_bytes_size": 7,
-            "translation": "큰[END]"
+            "translation": "큰 [END]"
         },
         {
             "offset": 1805936,
@@ -642,14 +642,14 @@
             "string": "コラボ結構[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 훌륭한[END]"
+            "translation": "콜라보 훌륭한 [END]"
         },
         {
             "offset": 1806072,
             "string": "結構[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "훌륭한[END]"
+            "translation": "훌륭한 [END]"
         },
         {
             "offset": 1806080,
@@ -677,14 +677,14 @@
             "string": "コラボかなり[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 꽤 하는[END]"
+            "translation": "콜라보 꽤 하는 [END]"
         },
         {
             "offset": 1806224,
             "string": "かなり[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "꽤 하는[END]"
+            "translation": "꽤 하는 [END]"
         },
         {
             "offset": 1806232,
@@ -712,14 +712,14 @@
             "string": "コラボ１ポンド[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 1파운드[END]"
+            "translation": "콜라보 1파운드 [END]"
         },
         {
             "offset": 1806384,
             "string": "１ポンド[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "1파운드[END]"
+            "translation": "1파운드 [END]"
         },
         {
             "offset": 1806400,
@@ -747,14 +747,14 @@
             "string": "コラボ半端ない[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 장난 아닌[END]"
+            "translation": "콜라보 장난 아닌 [END]"
         },
         {
             "offset": 1806544,
             "string": "半端ない[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "장난 아닌[END]"
+            "translation": "장난 아닌 [END]"
         },
         {
             "offset": 1806560,
@@ -817,14 +817,14 @@
             "string": "コラボオニオン[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 양파[END]"
+            "translation": "콜라보 양파 [END]"
         },
         {
             "offset": 1806840,
             "string": "オニオン[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "양파[END]"
+            "translation": "양파 [END]"
         },
         {
             "offset": 1806856,
@@ -852,14 +852,14 @@
             "string": "コラボ特製[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 특제[END]"
+            "translation": "콜라보 특제 [END]"
         },
         {
             "offset": 1807008,
             "string": "特製[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "특제[END]"
+            "translation": "특제 [END]"
         },
         {
             "offset": 1807016,
@@ -887,14 +887,14 @@
             "string": "コラボとろとろ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 뭉근한[END]"
+            "translation": "콜라보 뭉근한 [END]"
         },
         {
             "offset": 1807160,
             "string": "とろとろ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "뭉근한[END]"
+            "translation": "뭉근한 [END]"
         },
         {
             "offset": 1807176,
@@ -922,14 +922,14 @@
             "string": "コラボリゾート[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 리조트[END]"
+            "translation": "콜라보 리조트 [END]"
         },
         {
             "offset": 1807336,
             "string": "リゾート[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "리조트[END]"
+            "translation": "리조트 [END]"
         },
         {
             "offset": 1807352,
@@ -957,14 +957,14 @@
             "string": "コラボこってり[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 진한[END]"
+            "translation": "콜라보 진한 [END]"
         },
         {
             "offset": 1807488,
             "string": "こってり[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "진한[END]"
+            "translation": "진한 [END]"
         },
         {
             "offset": 1807504,
@@ -992,14 +992,14 @@
             "string": "コラボとびきり[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 특별한[END]"
+            "translation": "콜라보 특별한 [END]"
         },
         {
             "offset": 1807656,
             "string": "とびきり[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "특별한[END]"
+            "translation": "특별한 [END]"
         },
         {
             "offset": 1807672,
@@ -1027,14 +1027,14 @@
             "string": "コラボ二代目[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 2대째[END]"
+            "translation": "콜라보 2대째 [END]"
         },
         {
             "offset": 1807816,
             "string": "二代目[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "2대째[END]"
+            "translation": "2대째 [END]"
         },
         {
             "offset": 1807824,
@@ -1062,14 +1062,14 @@
             "string": "コラボ特盛[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 특대[END]"
+            "translation": "콜라보 특대 [END]"
         },
         {
             "offset": 1807960,
             "string": "特盛[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "특대[END]"
+            "translation": "특대 [END]"
         },
         {
             "offset": 1807968,
@@ -1132,14 +1132,14 @@
             "string": "コラボ回鍋[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 두 번 찐[END]"
+            "translation": "콜라보 두 번 찐 [END]"
         },
         {
             "offset": 1808256,
             "string": "回鍋[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "두 번 찐[END]"
+            "translation": "두 번 찐 [END]"
         },
         {
             "offset": 1808264,
@@ -1167,14 +1167,14 @@
             "string": "コラボ激辛[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 아주 매운[END]"
+            "translation": "콜라보 아주 매운 [END]"
         },
         {
             "offset": 1808408,
             "string": "激辛[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "아주 매운[END]"
+            "translation": "아주 매운 [END]"
         },
         {
             "offset": 1808416,
@@ -1202,14 +1202,14 @@
             "string": "コラボマフ[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 머플러[END]"
+            "translation": "콜라보 머플러 [END]"
         },
         {
             "offset": 1808544,
             "string": "マフ[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "머플러[END]"
+            "translation": "머플러 [END]"
         },
         {
             "offset": 1808552,
@@ -1237,14 +1237,14 @@
             "string": "コラボ武勇[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 무쌍[END]"
+            "translation": "콜라보 무쌍 [END]"
         },
         {
             "offset": 1808704,
             "string": "武勇[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "무쌍[END]"
+            "translation": "무쌍 [END]"
         },
         {
             "offset": 1808712,
@@ -1272,14 +1272,14 @@
             "string": "コラボ山の幸[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 육지산[END]"
+            "translation": "콜라보 육지산 [END]"
         },
         {
             "offset": 1808856,
             "string": "山の幸[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "육지산[END]"
+            "translation": "육지산 [END]"
         },
         {
             "offset": 1808864,
@@ -1307,14 +1307,14 @@
             "string": "コラボ思わず[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 어머나[END]"
+            "translation": "콜라보 신기한 [END]"
         },
         {
             "offset": 1809008,
             "string": "思わず[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "어머나[END]"
+            "translation": "신기한 [END]"
         },
         {
             "offset": 1809016,
@@ -1342,14 +1342,14 @@
             "string": "コラボ辛口[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 매운 맛[END]"
+            "translation": "콜라보 매운 맛 [END]"
         },
         {
             "offset": 1809168,
             "string": "辛口[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "매운 맛[END]"
+            "translation": "매운 맛 [END]"
         },
         {
             "offset": 1809176,
@@ -1377,14 +1377,14 @@
             "string": "コラボふわふわ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 폭신폭신[END]"
+            "translation": "콜라보 폭신폭신 [END]"
         },
         {
             "offset": 1809328,
             "string": "ふわふわ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "폭신폭신[END]"
+            "translation": "폭신폭신 [END]"
         },
         {
             "offset": 1809344,
@@ -1412,14 +1412,14 @@
             "string": "コラボパラパラ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 고슬고슬[END]"
+            "translation": "콜라보 고슬고슬 [END]"
         },
         {
             "offset": 1809488,
             "string": "パラパラ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "고슬고슬[END]"
+            "translation": "고슬고슬 [END]"
         },
         {
             "offset": 1809504,
@@ -1447,14 +1447,14 @@
             "string": "コラボかつ[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 가다랑어[END]"
+            "translation": "콜라보 가다랑어 [END]"
         },
         {
             "offset": 1809648,
             "string": "かつ[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "가다랑어[END]"
+            "translation": "가다랑어 [END]"
         },
         {
             "offset": 1809656,
@@ -1482,14 +1482,14 @@
             "string": "コラボ千夜[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 천일 묵은[END]"
+            "translation": "콜라보 천일 묵은 [END]"
         },
         {
             "offset": 1809800,
             "string": "千夜[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "천일 묵은[END]"
+            "translation": "천일 묵은 [END]"
         },
         {
             "offset": 1809808,
@@ -1517,14 +1517,14 @@
             "string": "コラボすご[END]",
             "original_bytes_length": 11,
             "available_bytes_size": 15,
-            "translation": "콜라보 엄청난[END]"
+            "translation": "콜라보 엄청난 [END]"
         },
         {
             "offset": 1809928,
             "string": "すご[END]",
             "original_bytes_length": 5,
             "available_bytes_size": 7,
-            "translation": "엄청난[END]"
+            "translation": "엄청난 [END]"
         },
         {
             "offset": 1809936,
@@ -1552,14 +1552,14 @@
             "string": "コラボあつあつ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 뜨끈뜨끈[END]"
+            "translation": "콜라보 뜨끈뜨끈 [END]"
         },
         {
             "offset": 1810064,
             "string": "あつあつ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "뜨끈뜨끈[END]"
+            "translation": "뜨끈뜨끈 [END]"
         },
         {
             "offset": 1810080,
@@ -1587,14 +1587,14 @@
             "string": "コラボほくほく[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 따끈따끈[END]"
+            "translation": "콜라보 따끈따끈 [END]"
         },
         {
             "offset": 1810208,
             "string": "ほくほく[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "따끈따끈[END]"
+            "translation": "따끈따끈 [END]"
         },
         {
             "offset": 1810224,
@@ -1622,14 +1622,14 @@
             "string": "コラボダブル[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "콜라보 더블[END]"
+            "translation": "콜라보 더블 [END]"
         },
         {
             "offset": 1810360,
             "string": "ダブル[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "더블[END]"
+            "translation": "더블 [END]"
         },
         {
             "offset": 1810368,
@@ -1657,14 +1657,14 @@
             "string": "コラボ黄金比率[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 황금 비율[END]"
+            "translation": "콜라보 황금 비율 [END]"
         },
         {
             "offset": 1810520,
             "string": "黄金比率[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "황금 비율[END]"
+            "translation": "황금 비율 [END]"
         },
         {
             "offset": 1810536,
@@ -1692,14 +1692,14 @@
             "string": "コラボシャキシャキ[END]",
             "original_bytes_length": 19,
             "available_bytes_size": 23,
-            "translation": "콜라보 아삭아삭[END]"
+            "translation": "콜라보 아삭아삭 [END]"
         },
         {
             "offset": 1810704,
             "string": "シャキシャキ[END]",
             "original_bytes_length": 13,
             "available_bytes_size": 15,
-            "translation": "아삭아삭[END]"
+            "translation": "아삭아삭 [END]"
         },
         {
             "offset": 1810720,
@@ -1727,14 +1727,14 @@
             "string": "コラボのりパリ[END]",
             "original_bytes_length": 15,
             "available_bytes_size": 15,
-            "translation": "콜라보 바삭김[END]"
+            "translation": "콜라보 바삭김 [END]"
         },
         {
             "offset": 1810872,
             "string": "のりパリ[END]",
             "original_bytes_length": 9,
             "available_bytes_size": 15,
-            "translation": "바삭김[END]"
+            "translation": "바삭김 [END]"
         },
         {
             "offset": 1810888,

--- a/translations/binaries/slps_strings_items_food.json
+++ b/translations/binaries/slps_strings_items_food.json
@@ -1545,7 +1545,7 @@
             "string": "焼き鳥[END]",
             "original_bytes_length": 7,
             "available_bytes_size": 7,
-            "translation": "야키토리[END]"
+            "translation": "닭꼬치[END]"
         },
         {
             "offset": 1810048,


### PR DESCRIPTION
https://github.com/ToD-DC-Kor/kor-patch/issues/484 에서 말씀하신 강초래 관련 텍스트 수정 1건과 음식 설명 파일 수정입니다.

특이사항은 음식 정렬 기준 위에서=파일 기준 아래쪽부터 차례대로 설명해둘게요

- ブリトー(브리또)→부리토 : 표준 표기가 이쪽인 것 같아서... 
- きつねうどん(여우 우동)→유부우동 : きつね를 유부라는 뜻으로도 씁니다.
- 一夜漬け(이치야즈케)→겉절이 : 채소 절임으로 번역 관련 얘기 있었던 것 같은데요. 아무래도 하룻밤 뚝딱 절이는 거는 역시 겉절이...겠죠
- かつ(돈까스)→가다랑어 : 음식 이름인 오차즈케까지 합쳐서 かつお茶漬け로 가다랑어 오차즈케가 되기 때문에 가다랑어입니다.
- 思わず(놀라움)→어머나 : 이거 발음이 오모와즈라서 오모와즈오무하야시 같은 느낌으로 발음 비슷한 걸로 말장난하는 건데,
그래서 최디한 오므... 한 발음이 나면서 뜻이 비슷한 걸로 어떻게든... 한 건데 역시 평범하게 신기한이나 놀라운 정도가 맞을 것 같기도 하네요
- 파엘리아(パエリア)→파에야 : 이쪽은 이름보다는 설명에 들어간 사프란 육수가 아이템명이 샤프란(데스티니2에서 샤프란이라서)으로 되어 있어서 이쪽 어떻게 통일해야 좋을지 얘기 필요할 것 같아요-
- 武勇(무용)→무쌍 : 오리엔탈 라이스와 이름이 비슷한 일본의 코미디언 오리엔탈 라디오의 만담 무용전에서 따온 걸로 추정되는데
무용이 꽤 여러 뜻으로 읽힐 수 있는데다 아무리 생각해도 한국 사람 대부분이 이해할 드립이 아니라 좀 바꿨습니다.
- 蒸しぱん(찐빵)→술빵 : 뜻 자체는 찐빵이 맞는데 이게 가리키는 음식이 우리나라 사람이 일반적으로 생각하는 동글동글 찐빵이 전혀 아니고 제일 가까운 게 술빵 느낌이라서 이렇게 했어요-
- 肉まん(고기만두)→고기호빵 : 호빵 찐빵 계열에 더 가까운 거는 오히려 이 쪽이네요! 정확히는 중국식 빠오즈 계열 느낌... 아무튼 일반적으로 생각하는 피 얇고 말랑말랑한 비비고 만두같은 느낌은 전혀 아닙니다.
- 回鍋(회귀)→두 번 찐 : 회과육의 그 回锅로, 찜솥으로 회귀한다... 고 보면 딱히 틀리지는 않았지만 고기호빵과 영 안 어울리는 접두사라 의역했습니다.
- ハンバーグ(햄버거)→햄버그 : 햄버그 스테이크/함박 스테이크. 원래는 뒤에 스테이크까지 붙일까 했는데 글자수가 너무 길어지는 것 같아서 뺐어요.
- サイコロステーキ(사이코로 스테이크)→큐브 스테이크 : 사이코로는 주사위라서 주사위 비슷한 모양으로 자른 스테이크고 그래서 큐브 스테이크예요.
- すき焼き(스키야키) : 원래 전골로 하려다가 다른 전골이 많이 있어서 일단 그대로 놔두긴 했는데 음식 이름 다른 것처럼 풀어서 쓰려면 불고기로 바꾸는 게 좋을까요?
- お(오)→큰 : 생선회의 お刺身 앞에 붙어서 おお=크다가 됩니다.
- トロのあぶり握り(참치 초밥)→구운 참치 초밥 : あぶり握り는 토치로 겉을 살짝 지진 초밥이에요.
- 舟盛り(후나모리)→모둠회 : 회는 회인데 그냥 회하고는 접시가 배 모양이냐 아니냐 차이인 느낌이라... 모양까지 살린 이름은 군함회 정도가 될텐데 이러면 또 군함말이 초밥하고 헷갈릴 것 같네요!
- フルーツサラダ(과일 샐러드)→과일 사라다 : 스트랩이 있는 음식이 아니라 이미지를 못 봐서 확실하지는 않은데, 일반적 샐러드하고 다른 마요네즈 비빈 허옇고 깍둑썰기한 음식일 가능성이 높습니다.
국내에서는 보통 그런 걸 서양식 샐러드하고 구분해서 부르려고 아예 사라다라고 쓰는 경우가 꽤 있더라고요.
- ビューチ(뷰치)→아름다운 : 과일 치즈의 앞부분인 フルー와 합쳐서 뷰티풀이 됩니다.
- パワ(파워)→강력 : 마찬가지로 フルー와 합쳐서 파워풀이 됩니다.
- 魚鍋(생선 전골)→해물탕 : 매운탕... 이라고 하기에는 아무래도 안 매워서. 그냥 해물탕. 고기 전골도 그렇고 ~~가 메인인 전골. 설명 문장은 너무 당연한데다 정보값이 전혀 없어서 글자수 맞추려고 생략했습니다.
- まんぼうの串焼き(개복치 꼬치구이) : 개복치 이름이 맘보가 되느냐 개복치가 되느냐가 아직 결정 안 된 것 같아서 일단 이대로 놔뒀어요-
- 親(부모)→대박 : 親まん으로 마작 용어 오야만관인데, 마작 용어를 잘 모르지만 일단 점수가 많이 나온 것 같아서 대박 정도로 해뒀습니다.
- あわせ(조화)→모둠 : みそ와 합해서 あわせみそ로 여러 종류를 섞어서 만든 블렌디드 된장 같은 건데요. 모둠으로 하면 어묵이 많다는 느낌이라 좀 수정하고 싶은데 좋은 단어가 생각이 안 나네요!
- ウ(우)→엄 : 마파 카레의 맨 앞 글자인 マ와 합쳐서 ウマ=말이 됩니다. 맨 처음 생각난 건 우마무스메인데 말딸 마파 카레란 대체 뭔가 싶어서...
엄으로 하면 엄마파 카레로 말도 되고 맛있는 것 같고 좋지 않나 싶어서 일단 이렇게 해뒀습니다. 더 좋은 수식어가 있다면 바꿔도 괜찮을 것 같아요.
- 目がチ(눈이 찌)→따끔따끔 : 目がチカチカ로 눈이 따갑다는 뜻이네요. 원래 뜻대로 하면 눈 따가운 정도가 맞긴 합니다.
- パサパサンドイッチ(퍼석퍼석 샌드위치)→바싹 마른 샌드위치 : 수식어인 퍼석퍼석을 パサ 쪽으로 옮기면서 이름을 바꿨습니다.
- 懐か(그리움)→퍼진 : 懐か+し로 그리운 게 맞는데 왜 퍼졌다고 썼을까요... 그냥 그리움이라고 하면 눅눅한과 말이 안 맞으니까 추억의 정도로 바꿔두는 게 좋을 것 같네요
- 四(사)→ 완전 : 덜 익은 케밥의 半生이 인생의 절반이라는 뜻 정도로도 쓰이고, 四半生은 그의 절반... 그러니까 흔히 반오십 정도로 쓰이기도 해서 덜 익은 거의 덜 익은 거는 완전 덜 익었다는 느낌으로 이렇게 해뒀어요.



번역하기 애매한 말장난이 하도 많아서 왜 이렇게 했는지에 대한 설명도 엄청 길어지네요!
진짜 무시무시하게 어렵고 머리 아프긴 합니다...